### PR TITLE
.travis.yml: initial commit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: cpp
+
+addons:
+  apt:
+    packages:
+      - gfortran
+
+script:
+ - ./configure
+ - make
+ - make install DESTDIR=${PWD}


### PR DESCRIPTION
Rudimentary CI support, result here:
https://travis-ci.org/junghans/kim-api/builds/363283005

Travis still needs to enable for the openkim github organization (https://travis-ci.org/openkim) to get this on every pull request.