### PR TITLE
Fix verbosity specification in cpp log headers

### DIFF
--- a/cpp/include/KIM_ModelDestroyLogMacros.hpp
+++ b/cpp/include/KIM_ModelDestroyLogMacros.hpp
@@ -38,7 +38,7 @@
 #endif
 #if (KIM_LOG_MAXIMUM_LEVEL >= KIM_LOG_VERBOSITY_FATAL_)
 #define LOG_FATAL(message)                                              \
-  modelDestroy->LogEntry(KIM::LOG_VERBOSITY::fatal, message,              \
+  modelDestroy->LogEntry(KIM::LOG_VERBOSITY::fatal, message,            \
                          __LINE__, __FILE__)
 #else
 #define LOG_FATAL(message)
@@ -51,7 +51,7 @@
 #endif
 #if (KIM_LOG_MAXIMUM_LEVEL >= KIM_LOG_VERBOSITY_ERROR_)
 #define LOG_ERROR(message)                                              \
-  modelDestroy->LogEntry(KIM::LOG_VERBOSITY::error, message,              \
+  modelDestroy->LogEntry(KIM::LOG_VERBOSITY::error, message,            \
                          __LINE__, __FILE__)
 #else
 #define LOG_ERROR(message)
@@ -64,7 +64,7 @@
 #endif
 #if (KIM_LOG_MAXIMUM_LEVEL >= KIM_LOG_VERBOSITY_WARNING_)
 #define LOG_WARNING(message)                                            \
-  modelDestroy->LogEntry(KIM::LOG_VERBOSITY::warning, message,            \
+  modelDestroy->LogEntry(KIM::LOG_VERBOSITY::warning, message,          \
                          __LINE__, __FILE__)
 #else
 #define LOG_WARNING(message)
@@ -77,7 +77,7 @@
 #endif
 #if (KIM_LOG_MAXIMUM_LEVEL >= KIM_LOG_VERBOSITY_INFORMATION_)
 #define LOG_INFORMATION(message)                                        \
-  modelDestroy->LogEntry(KIM::LOG_VERBOSITY::information, message,        \
+  modelDestroy->LogEntry(KIM::LOG_VERBOSITY::information, message,      \
                          __LINE__, __FILE__)
 #else
 #define LOG_INFORMATION(message)
@@ -90,7 +90,7 @@
 #endif
 #if (KIM_LOG_MAXIMUM_LEVEL >= KIM_LOG_VERBOSITY_DEBUG_)
 #define LOG_DEBUG(message)                                              \
-  modelDestroy->LogEntry(KIM::LOG_VERBOSITY::debug, message,              \
+  modelDestroy->LogEntry(KIM::LOG_VERBOSITY::debug, message,            \
                          __LINE__, __FILE__)
 #else
 #define LOG_DEBUG(message)

--- a/cpp/include/KIM_ModelRefreshLogMacros.hpp
+++ b/cpp/include/KIM_ModelRefreshLogMacros.hpp
@@ -37,7 +37,7 @@
 #undef LOG_FATAL
 #endif
 #if (KIM_LOG_MAXIMUM_LEVEL >= KIM_LOG_VERBOSITY_FATAL_)
-#define LOG_FATAL(message)                                          \
+#define LOG_FATAL(message)                                            \
   modelRefresh->LogEntry(KIM::LOG_VERBOSITY::fatal, message,          \
                          __LINE__, __FILE__)
 #else
@@ -50,7 +50,7 @@
 #undef LOG_ERROR
 #endif
 #if (KIM_LOG_MAXIMUM_LEVEL >= KIM_LOG_VERBOSITY_ERROR_)
-#define LOG_ERROR(message)                                          \
+#define LOG_ERROR(message)                                            \
   modelRefresh->LogEntry(KIM::LOG_VERBOSITY::error, message,          \
                          __LINE__, __FILE__)
 #else
@@ -63,7 +63,7 @@
 #undef LOG_WARNING
 #endif
 #if (KIM_LOG_MAXIMUM_LEVEL >= KIM_LOG_VERBOSITY_WARNING_)
-#define LOG_WARNING(message)                                        \
+#define LOG_WARNING(message)                                          \
   modelRefresh->LogEntry(KIM::LOG_VERBOSITY::warning, message,        \
                          __LINE__, __FILE__)
 #else
@@ -76,7 +76,7 @@
 #undef LOG_INFORMATION
 #endif
 #if (KIM_LOG_MAXIMUM_LEVEL >= KIM_LOG_VERBOSITY_INFORMATION_)
-#define LOG_INFORMATION(message)                                    \
+#define LOG_INFORMATION(message)                                      \
   modelRefresh->LogEntry(KIM::LOG_VERBOSITY::information, message,    \
                          __LINE__, __FILE__)
 #else
@@ -89,7 +89,7 @@
 #undef LOG_DEBUG
 #endif
 #if (KIM_LOG_MAXIMUM_LEVEL >= KIM_LOG_VERBOSITY_DEBUG_)
-#define LOG_DEBUG(message)                                          \
+#define LOG_DEBUG(message)                                            \
   modelRefresh->LogEntry(KIM::LOG_VERBOSITY::debug, message,          \
                          __LINE__, __FILE__)
 #else


### PR DESCRIPTION
It appears C bindings were mistakenly used in the cpp log macro headers.