### PR TITLE
Add /usr/share/kim-api-v2/cmake to the CMAKE_MODULE_PATH

### DIFF
--- a/examples/model-drivers/LennardJones612__MD_414112407348_003/CMakeLists.txt
+++ b/examples/model-drivers/LennardJones612__MD_414112407348_003/CMakeLists.txt
@@ -39,7 +39,7 @@
 
 cmake_minimum_required(VERSION 3.4)
 
-list(APPEND CMAKE_MODULE_PATH $ENV{KIM_API_V2_CMAKE_MODULES_DIR})
+list(APPEND CMAKE_MODULE_PATH $ENV{KIM_API_V2_CMAKE_MODULES_DIR} "/usr/share/kim-api-v2/cmake")
 find_package(KIM-API-V2 2.0 REQUIRED)
 if(NOT TARGET kim-api)
   project("${KIM_API_PROJECT_NAME}" VERSION "${KIM_API_VERSION}"

--- a/examples/model-drivers/ex_model_driver_P_LJ/CMakeLists.txt
+++ b/examples/model-drivers/ex_model_driver_P_LJ/CMakeLists.txt
@@ -39,7 +39,7 @@
 
 cmake_minimum_required(VERSION 3.4)
 
-list(APPEND CMAKE_MODULE_PATH $ENV{KIM_API_V2_CMAKE_MODULES_DIR})
+list(APPEND CMAKE_MODULE_PATH $ENV{KIM_API_V2_CMAKE_MODULES_DIR} "/usr/share/kim-api-v2/cmake")
 find_package(KIM-API-V2 2.0 REQUIRED)
 if(NOT TARGET kim-api)
   project("${KIM_API_PROJECT_NAME}" VERSION "${KIM_API_VERSION}"

--- a/examples/model-drivers/ex_model_driver_P_Morse/CMakeLists.txt
+++ b/examples/model-drivers/ex_model_driver_P_Morse/CMakeLists.txt
@@ -39,7 +39,7 @@
 
 cmake_minimum_required(VERSION 3.4)
 
-list(APPEND CMAKE_MODULE_PATH $ENV{KIM_API_V2_CMAKE_MODULES_DIR})
+list(APPEND CMAKE_MODULE_PATH $ENV{KIM_API_V2_CMAKE_MODULES_DIR} "/usr/share/kim-api-v2/cmake")
 find_package(KIM-API-V2 2.0 REQUIRED)
 if(NOT TARGET kim-api)
   project("${KIM_API_PROJECT_NAME}" VERSION "${KIM_API_VERSION}"

--- a/examples/models/LennardJones612_UniversalShifted__MO_959249795837_003/CMakeLists.txt
+++ b/examples/models/LennardJones612_UniversalShifted__MO_959249795837_003/CMakeLists.txt
@@ -39,7 +39,7 @@
 
 cmake_minimum_required(VERSION 3.4)
 
-list(APPEND CMAKE_MODULE_PATH $ENV{KIM_API_V2_CMAKE_MODULES_DIR})
+list(APPEND CMAKE_MODULE_PATH $ENV{KIM_API_V2_CMAKE_MODULES_DIR} "/usr/share/kim-api-v2/cmake")
 find_package(KIM-API-V2 2.0 REQUIRED)
 if(NOT TARGET kim-api)
   project("${KIM_API_PROJECT_NAME}" VERSION "${KIM_API_VERSION}"

--- a/examples/models/LennardJones_Ar/CMakeLists.txt
+++ b/examples/models/LennardJones_Ar/CMakeLists.txt
@@ -39,7 +39,7 @@
 
 cmake_minimum_required(VERSION 3.4)
 
-list(APPEND CMAKE_MODULE_PATH $ENV{KIM_API_V2_CMAKE_MODULES_DIR})
+list(APPEND CMAKE_MODULE_PATH $ENV{KIM_API_V2_CMAKE_MODULES_DIR} "/usr/share/kim-api-v2/cmake")
 find_package(KIM-API-V2 2.0 REQUIRED)
 if(NOT TARGET kim-api)
   project("${KIM_API_PROJECT_NAME}" VERSION "${KIM_API_VERSION}"

--- a/examples/models/Sim_LAMMPS_ADP_StarikovLopanitsynaSmirnova_2018_SiAu__SM_985135773293_000/CMakeLists.txt
+++ b/examples/models/Sim_LAMMPS_ADP_StarikovLopanitsynaSmirnova_2018_SiAu__SM_985135773293_000/CMakeLists.txt
@@ -39,7 +39,7 @@
 
 cmake_minimum_required(VERSION 3.4)
 
-list(APPEND CMAKE_MODULE_PATH $ENV{KIM_API_V2_CMAKE_MODULES_DIR})
+list(APPEND CMAKE_MODULE_PATH $ENV{KIM_API_V2_CMAKE_MODULES_DIR} "/usr/share/kim-api-v2/cmake")
 find_package(KIM-API-V2 2.0 REQUIRED)
 if(NOT TARGET kim-api)
   project("${KIM_API_PROJECT_NAME}" VERSION "${KIM_API_VERSION}"

--- a/examples/models/ex_model_Ar_P_LJ/CMakeLists.txt
+++ b/examples/models/ex_model_Ar_P_LJ/CMakeLists.txt
@@ -39,7 +39,7 @@
 
 cmake_minimum_required(VERSION 3.4)
 
-list(APPEND CMAKE_MODULE_PATH $ENV{KIM_API_V2_CMAKE_MODULES_DIR})
+list(APPEND CMAKE_MODULE_PATH $ENV{KIM_API_V2_CMAKE_MODULES_DIR} "/usr/share/kim-api-v2/cmake")
 find_package(KIM-API-V2 2.0 REQUIRED)
 if(NOT TARGET kim-api)
   project("${KIM_API_PROJECT_NAME}" VERSION "${KIM_API_VERSION}"

--- a/examples/models/ex_model_Ar_P_MLJ_Fortran/CMakeLists.txt
+++ b/examples/models/ex_model_Ar_P_MLJ_Fortran/CMakeLists.txt
@@ -39,7 +39,7 @@
 
 cmake_minimum_required(VERSION 3.4)
 
-list(APPEND CMAKE_MODULE_PATH $ENV{KIM_API_V2_CMAKE_MODULES_DIR})
+list(APPEND CMAKE_MODULE_PATH $ENV{KIM_API_V2_CMAKE_MODULES_DIR} "/usr/share/kim-api-v2/cmake")
 find_package(KIM-API-V2 2.0 REQUIRED)
 if(NOT TARGET kim-api)
   project("${KIM_API_PROJECT_NAME}" VERSION "${KIM_API_VERSION}"

--- a/examples/models/ex_model_Ar_P_Morse/CMakeLists.txt
+++ b/examples/models/ex_model_Ar_P_Morse/CMakeLists.txt
@@ -39,7 +39,7 @@
 
 cmake_minimum_required(VERSION 3.4)
 
-list(APPEND CMAKE_MODULE_PATH $ENV{KIM_API_V2_CMAKE_MODULES_DIR})
+list(APPEND CMAKE_MODULE_PATH $ENV{KIM_API_V2_CMAKE_MODULES_DIR} "/usr/share/kim-api-v2/cmake")
 find_package(KIM-API-V2 2.0 REQUIRED)
 if(NOT TARGET kim-api)
   project("${KIM_API_PROJECT_NAME}" VERSION "${KIM_API_VERSION}"

--- a/examples/models/ex_model_Ar_P_Morse_07C/CMakeLists.txt
+++ b/examples/models/ex_model_Ar_P_Morse_07C/CMakeLists.txt
@@ -39,7 +39,7 @@
 
 cmake_minimum_required(VERSION 3.4)
 
-list(APPEND CMAKE_MODULE_PATH $ENV{KIM_API_V2_CMAKE_MODULES_DIR})
+list(APPEND CMAKE_MODULE_PATH $ENV{KIM_API_V2_CMAKE_MODULES_DIR} "/usr/share/kim-api-v2/cmake")
 find_package(KIM-API-V2 2.0 REQUIRED)
 if(NOT TARGET kim-api)
   project("${KIM_API_PROJECT_NAME}" VERSION "${KIM_API_VERSION}"

--- a/examples/simulators/ex_test_Ar_fcc_cluster/CMakeLists.txt
+++ b/examples/simulators/ex_test_Ar_fcc_cluster/CMakeLists.txt
@@ -39,7 +39,7 @@
 
 cmake_minimum_required(VERSION 3.4)
 
-list(APPEND CMAKE_MODULE_PATH $ENV{KIM_API_V2_CMAKE_MODULES_DIR})
+list(APPEND CMAKE_MODULE_PATH $ENV{KIM_API_V2_CMAKE_MODULES_DIR} "/usr/share/kim-api-v2/cmake")
 find_package(KIM-API-V2 2.0 REQUIRED)
 if(NOT TARGET kim-api)
   project("${KIM_API_PROJECT_NAME}" VERSION "${KIM_API_VERSION}"

--- a/examples/simulators/ex_test_Ar_fcc_cluster_cpp/CMakeLists.txt
+++ b/examples/simulators/ex_test_Ar_fcc_cluster_cpp/CMakeLists.txt
@@ -39,7 +39,7 @@
 
 cmake_minimum_required(VERSION 3.4)
 
-list(APPEND CMAKE_MODULE_PATH $ENV{KIM_API_V2_CMAKE_MODULES_DIR})
+list(APPEND CMAKE_MODULE_PATH $ENV{KIM_API_V2_CMAKE_MODULES_DIR} "/usr/share/kim-api-v2/cmake")
 find_package(KIM-API-V2 2.0 REQUIRED)
 if(NOT TARGET kim-api)
   project("${KIM_API_PROJECT_NAME}" VERSION "${KIM_API_VERSION}"

--- a/examples/simulators/ex_test_Ar_fcc_cluster_fortran/CMakeLists.txt
+++ b/examples/simulators/ex_test_Ar_fcc_cluster_fortran/CMakeLists.txt
@@ -39,7 +39,7 @@
 
 cmake_minimum_required(VERSION 3.4)
 
-list(APPEND CMAKE_MODULE_PATH $ENV{KIM_API_V2_CMAKE_MODULES_DIR})
+list(APPEND CMAKE_MODULE_PATH $ENV{KIM_API_V2_CMAKE_MODULES_DIR} "/usr/share/kim-api-v2/cmake")
 find_package(KIM-API-V2 2.0 REQUIRED)
 if(NOT TARGET kim-api)
   project("${KIM_API_PROJECT_NAME}" VERSION "${KIM_API_VERSION}"


### PR DESCRIPTION
Please consider this patch

    Add /usr/share/kim-api-v2/cmake to the CMAKE_MODULE_PATH
    
    For DEB-packages we install the FindKIM-API-V2.cmake into the /usr/share/kim-api-v2/cmake
    It would be good to add this path into the CMAKE_MODULE_PATH so
    the user do not need to define KIM_API_V2_CMAKE_MODULES_DIR explicitly
    through environment.
