### PR TITLE
Parameter name

### DIFF
--- a/c/include/KIM_Model.h
+++ b/c/include/KIM_Model.h
@@ -150,10 +150,10 @@ int KIM_Model_GetSpeciesSupportAndCode(KIM_Model const * const model,
 
 void KIM_Model_GetNumberOfParameters(KIM_Model const * const model,
                                      int * const numberOfParameters);
-int KIM_Model_GetParameterDataTypeExtentAndDescription(
+int KIM_Model_GetParameterDataTypeExtentNameAndDescription(
     KIM_Model const * const model, int const parameterIndex,
     KIM_DataType * const dataType, int * const extent,
-    char const ** const description);
+    char const ** const name, char const ** const description);
 int KIM_Model_GetParameterInteger(KIM_Model const * const model,
                                   int const parameterIndex,
                                   int const arrayIndex,

--- a/c/include/KIM_ModelCreate.h
+++ b/c/include/KIM_ModelCreate.h
@@ -136,10 +136,12 @@ int KIM_ModelCreate_SetSpeciesCode(
 
 int KIM_ModelCreate_SetParameterPointerInteger(
     KIM_ModelCreate * const modelCreate,
-    int const extent, int * const ptr, char const * const description);
+    int const extent, int * const ptr, char const * const name,
+    char const * const description);
 int KIM_ModelCreate_SetParameterPointerDouble(
     KIM_ModelCreate * const modelCreate,
-    int const extent, double * const ptr, char const * const description);
+    int const extent, double * const ptr, char const * const name,
+    char const * const description);
 
 void KIM_ModelCreate_SetModelBufferPointer(
     KIM_ModelCreate * const modelCreate, void * const ptr);

--- a/c/include/KIM_ModelDriverCreate.h
+++ b/c/include/KIM_ModelDriverCreate.h
@@ -144,10 +144,12 @@ int KIM_ModelDriverCreate_SetSpeciesCode(
 
 int KIM_ModelDriverCreate_SetParameterPointerInteger(
     KIM_ModelDriverCreate * const modelDriverCreate,
-    int const extent, int * const ptr, char const * const description);
+    int const extent, int * const ptr, char const * const name,
+    char const * const description);
 int KIM_ModelDriverCreate_SetParameterPointerDouble(
     KIM_ModelDriverCreate * const modelDriverCreate,
-    int const extent, double * const ptr, char const * const description);
+    int const extent, double * const ptr, char const * const name,
+    char const * const description);
 
 void KIM_ModelDriverCreate_SetModelBufferPointer(
     KIM_ModelDriverCreate * const modelDriverCreate,

--- a/c/src/KIM_ModelCreate_c.cpp
+++ b/c/src/KIM_ModelCreate_c.cpp
@@ -246,20 +246,22 @@ int KIM_ModelCreate_SetSpeciesCode(
 
 int KIM_ModelCreate_SetParameterPointerInteger(
     KIM_ModelCreate * const modelCreate,
-    int const extent, int * const ptr, char const * const description)
+    int const extent, int * const ptr, char const * const name,
+    char const * const description)
 {
   CONVERT_POINTER;
 
-  return pModelCreate->SetParameterPointer(extent, ptr, description);
+  return pModelCreate->SetParameterPointer(extent, ptr, name, description);
 }
 
 int KIM_ModelCreate_SetParameterPointerDouble(
     KIM_ModelCreate * const modelCreate,
-    int const extent, double * const ptr, char const * const description)
+    int const extent, double * const ptr, char const * const name,
+    char const * const description)
 {
   CONVERT_POINTER;
 
-  return pModelCreate->SetParameterPointer(extent, ptr, description);
+  return pModelCreate->SetParameterPointer(extent, ptr, name, description);
 }
 
 void KIM_ModelCreate_SetModelBufferPointer(

--- a/c/src/KIM_ModelDriverCreate_c.cpp
+++ b/c/src/KIM_ModelDriverCreate_c.cpp
@@ -284,22 +284,24 @@ int KIM_ModelDriverCreate_SetSpeciesCode(
 
 int KIM_ModelDriverCreate_SetParameterPointerInteger(
     KIM_ModelDriverCreate * const modelDriverCreate,
-    int const extent, int * const ptr, char const * const description)
+    int const extent, int * const ptr, char const * const name,
+    char const * const description)
 {
   CONVERT_POINTER;
 
   return pModelDriverCreate->SetParameterPointer(
-      extent, ptr, description);
+      extent, ptr, name, description);
 }
 
 int KIM_ModelDriverCreate_SetParameterPointerDouble(
     KIM_ModelDriverCreate * const modelDriverCreate,
-    int const extent, double * const ptr, char const * const description)
+    int const extent, double * const ptr, char const * const name,
+    char const * const description)
 {
   CONVERT_POINTER;
 
   return pModelDriverCreate->SetParameterPointer(
-      extent, ptr, description);
+      extent, ptr, name, description);
 }
 
 void KIM_ModelDriverCreate_SetModelBufferPointer(

--- a/c/src/KIM_Model_c.cpp
+++ b/c/src/KIM_Model_c.cpp
@@ -332,10 +332,10 @@ void KIM_Model_GetNumberOfParameters(KIM_Model const * const model,
   pModel->GetNumberOfParameters(numberOfParameters);
 }
 
-int KIM_Model_GetParameterDataTypeExtentAndDescription(
+int KIM_Model_GetParameterDataTypeExtentNameAndDescription(
     KIM_Model const * const model, int const parameterIndex,
     KIM_DataType * const dataType, int * const extent,
-    char const ** const description)
+    char const ** const name, char const ** const description)
 {
   CONVERT_POINTER;
   KIM::DataType typ;
@@ -346,23 +346,31 @@ int KIM_Model_GetParameterDataTypeExtentAndDescription(
   else
     pTyp = &typ;
 
-  std::string const * pStr;
-  std::string const ** ppStr;
-  if (description == NULL)
-    ppStr = NULL;
+  std::string const * pStrName;
+  std::string const ** ppStrName;
+  if (name == NULL)
+    ppStrName = NULL;
   else
-    ppStr = &pStr;
+    ppStrName = &pStrName;
+
+  std::string const * pStrDesc;
+  std::string const ** ppStrDesc;
+  if (description == NULL)
+    ppStrDesc = NULL;
+  else
+    ppStrDesc = &pStrDesc;
 
   int error
-      = pModel->GetParameterDataTypeExtentAndDescription(
-          parameterIndex, pTyp, extent, ppStr);
+      = pModel->GetParameterDataTypeExtentNameAndDescription(
+          parameterIndex, pTyp, extent, ppStrName, ppStrDesc);
 
   if (error)
     return true;
   else
   {
     if (dataType != NULL) *dataType = makeDataTypeC(typ);
-    if (description != NULL) *description = pStr->c_str();
+    if (name != NULL) *name = pStrName->c_str();
+    if (description != NULL) *description = pStrDesc->c_str();
     return false;
   }
 }

--- a/cpp/include/KIM_Model.hpp
+++ b/cpp/include/KIM_Model.hpp
@@ -96,8 +96,9 @@ class Model
                                int * const code) const;
 
   void GetNumberOfParameters(int * const numberOfParameters) const;
-  int GetParameterDataTypeExtentAndDescription(
+  int GetParameterDataTypeExtentNameAndDescription(
       int const index, DataType * const dataType, int * extent,
+      std::string const ** const name,
       std::string const ** const description) const;
   int GetParameter(int const parameterIndex, int const arrayIndex,
                    int * const parameterValue) const;

--- a/cpp/include/KIM_ModelCreate.hpp
+++ b/cpp/include/KIM_ModelCreate.hpp
@@ -81,8 +81,10 @@ class ModelCreate
   int SetSpeciesCode(SpeciesName const speciesName, int const code);
 
   int SetParameterPointer(int const extent, int * const ptr,
+                          std::string const & name,
                           std::string const & description);
   int SetParameterPointer(int const extent, double * const ptr,
+                          std::string const & name,
                           std::string const & description);
 
   void SetModelBufferPointer(void * const ptr);

--- a/cpp/include/KIM_ModelDriverCreate.hpp
+++ b/cpp/include/KIM_ModelDriverCreate.hpp
@@ -85,8 +85,10 @@ class ModelDriverCreate
   int SetSpeciesCode(SpeciesName const speciesName, int const code);
 
   int SetParameterPointer(int const extent, int * const ptr,
+                          std::string const & name,
                           std::string const & description);
   int SetParameterPointer(int const extent, double * const ptr,
+                          std::string const & name,
                           std::string const & description);
 
   void SetModelBufferPointer(void * const ptr);

--- a/cpp/src/KIM_Model.cpp
+++ b/cpp/src/KIM_Model.cpp
@@ -143,12 +143,13 @@ void Model::GetNumberOfParameters(int * const numberOfParameters) const
   pimpl->GetNumberOfParameters(numberOfParameters);
 }
 
-int Model::GetParameterDataTypeExtentAndDescription(
+int Model::GetParameterDataTypeExtentNameAndDescription(
     int const parameterIndex, DataType * const dataType, int * const extent,
+    std::string const ** const name,
     std::string const ** const description) const
 {
-  return pimpl->GetParameterDataTypeExtentAndDescription(
-      parameterIndex, dataType, extent, description);
+  return pimpl->GetParameterDataTypeExtentNameAndDescription(
+      parameterIndex, dataType, extent, name, description);
 }
 
 int Model::GetParameter(

--- a/cpp/src/KIM_ModelCreate.cpp
+++ b/cpp/src/KIM_ModelCreate.cpp
@@ -122,20 +122,22 @@ int ModelCreate::SetSpeciesCode(SpeciesName const speciesName,
 }
 
 int ModelCreate::SetParameterPointer(int const extent, int * const ptr,
+                                     std::string const & name,
                                      std::string const & description)
 {
   CONVERT_POINTER;
 
-  return pImpl->SetParameterPointer(extent, ptr, description);
+  return pImpl->SetParameterPointer(extent, ptr, name, description);
 }
 
 int ModelCreate::SetParameterPointer(int const extent,
                                      double * const ptr,
+                                     std::string const & name,
                                      std::string const & description)
 {
   CONVERT_POINTER;
 
-  return pImpl->SetParameterPointer(extent, ptr, description);
+  return pImpl->SetParameterPointer(extent, ptr, name, description);
 }
 
 void ModelCreate::SetModelBufferPointer(void * const ptr)

--- a/cpp/src/KIM_ModelDriverCreate.cpp
+++ b/cpp/src/KIM_ModelDriverCreate.cpp
@@ -139,19 +139,21 @@ int ModelDriverCreate::SetSpeciesCode(SpeciesName const speciesName,
 }
 
 int ModelDriverCreate::SetParameterPointer(
-    int const extent, int * const ptr, std::string const & description)
+    int const extent, int * const ptr, std::string const & name,
+    std::string const & description)
 {
   CONVERT_POINTER;
 
-  return pImpl->SetParameterPointer(extent, ptr, description);
+  return pImpl->SetParameterPointer(extent, ptr, name, description);
 }
 
 int ModelDriverCreate::SetParameterPointer(
-    int const extent, double * const ptr, std::string const & description)
+    int const extent, double * const ptr, std::string const & name,
+    std::string const & description)
 {
   CONVERT_POINTER;
 
-  return pImpl->SetParameterPointer(extent, ptr, description);
+  return pImpl->SetParameterPointer(extent, ptr, name, description);
 }
 
 void ModelDriverCreate::SetModelBufferPointer(void * const ptr)

--- a/cpp/src/KIM_ModelImplementation.cpp
+++ b/cpp/src/KIM_ModelImplementation.cpp
@@ -36,6 +36,7 @@
 #include <cstdio>
 #include <cstring>
 #include <cmath>
+#include <algorithm>
 
 #ifndef KIM_LOG_HPP_
 #include "KIM_Log.hpp"
@@ -877,6 +878,15 @@ int ModelImplementation::SetParameterPointer(int const extent, int * const ptr,
     LOG_DEBUG("Exit 1=" + callString);
     return true;
   }
+
+  if (std::find(parameterName_.begin(), parameterName_.end(), name)
+      != parameterName_.end())
+  {
+    LOG_ERROR("Name '" + name + "' is already associated with another "
+              "parameter.  Parameter names must be unique.");
+    LOG_DEBUG("Exit 1=" + callString);
+    return true;
+  }
 #endif
 
   parameterName_.push_back(name);
@@ -911,6 +921,22 @@ int ModelImplementation::SetParameterPointer(int const extent,
   if (ptr == NULL)
   {
     LOG_ERROR("Null pointer provided for parameter.");
+    LOG_DEBUG("Exit 1=" + callString);
+    return true;
+  }
+
+  if (! IsCIdentifier(name))
+  {
+    LOG_ERROR("Name '" + name + "' is not a valid C identifier.");
+    LOG_DEBUG("Exit 1=" + callString);
+    return true;
+  }
+
+  if (std::find(parameterName_.begin(), parameterName_.end(), name)
+      != parameterName_.end())
+  {
+    LOG_ERROR("Name '" + name + "' is already associated with another "
+              "parameter.  Parameter names must be unique.");
     LOG_DEBUG("Exit 1=" + callString);
     return true;
   }

--- a/cpp/src/KIM_ModelImplementation.hpp
+++ b/cpp/src/KIM_ModelImplementation.hpp
@@ -154,13 +154,16 @@ class ModelImplementation
                            std::string const ** const parameterFileName) const;
 
   int SetParameterPointer(int const extent, int * const ptr,
+                          std::string const & name,
                           std::string const & description);
   int SetParameterPointer(int const extent, double * const ptr,
+                          std::string const & name,
                           std::string const & description);
   void GetNumberOfParameters(int * const numberOfParameters) const;
-  int GetParameterDataTypeExtentAndDescription(
+  int GetParameterDataTypeExtentNameAndDescription(
       int const parameterIndex, DataType * const dataType, int * const extent,
-      std::string const ** const description) const;
+      std::string const ** const name, std::string const ** const description)
+      const;
   int GetParameter(int const parameterIndex, int const arrayIndex,
                    int * const parameterValue) const;
   int GetParameter(int const parameterIndex, int const arrayIndex,
@@ -245,6 +248,8 @@ class ModelImplementation
   int Validate(TemperatureUnit const temperatureUnit) const;
   int Validate(TimeUnit const timeUnit) const;
 
+  int IsCIdentifier(std::string const & id) const;
+
   ModelLibrary::ITEM_TYPE modelType_;
   std::string modelName_;
   std::string modelDriverName_;
@@ -307,6 +312,7 @@ class ModelImplementation
   std::map<SpeciesName const, int, SPECIES_NAME::Comparator> supportedSpecies_;
 
 
+  std::vector<std::string> parameterName_;
   std::vector<std::string> parameterDescription_;
   std::vector<DataType> parameterDataType_;
   std::vector<int> parameterExtent_;

--- a/examples/model-drivers/LennardJones612__MD_414112407348_003/LennardJones612Implementation.cpp
+++ b/examples/model-drivers/LennardJones612__MD_414112407348_003/LennardJones612Implementation.cpp
@@ -28,6 +28,7 @@
 //
 
 
+#include <sstream>
 #include <cmath>
 #include <cstdlib>
 #include <cstring>
@@ -636,6 +637,10 @@ int LennardJones612Implementation::RegisterKIMComputeArgumentsSettings(
 }
 
 //******************************************************************************
+// helper macro
+#define SNUM( x ) static_cast<std::ostringstream &>(    \
+    std::ostringstream() << std::dec << x).str()
+//******************************************************************************
 #include "KIM_ModelDriverCreateLogMacros.hpp"
 int LennardJones612Implementation::RegisterKIMParameters(
     KIM::ModelDriverCreate * const modelDriverCreate)
@@ -643,28 +648,48 @@ int LennardJones612Implementation::RegisterKIMParameters(
   int ier = false;
 
   // publish parameters (order is important)
-  ier = modelDriverCreate->SetParameterPointer(1, &shift_, "shift");
+  ier = modelDriverCreate->SetParameterPointer(
+      1, &shift_, "shift",
+      "If (shift == 1), all LJ potentials are shifted to zero energy "
+      "at their respective cutoff distance.  Otherwise, no shifting is "
+      "performed.");
   if (ier)
   {
     LOG_ERROR("set_parameter shift");
     return ier;
   }
+
   ier = modelDriverCreate->SetParameterPointer(
-      numberUniqueSpeciesPairs_, cutoffs_, "cutoffs");
+      numberUniqueSpeciesPairs_, cutoffs_, "cutoffs",
+      "Lower-triangular matrix (of size N=" + SNUM(numberModelSpecies_) + ") "
+      "in row-major storage.  Ordering is according to SpeciesCode values.  "
+      "For example, to find the parameter related to SpeciesCode 'i' and "
+      "SpeciesCode 'j' (i >= j), use (zero-based) "
+      "index = (j*N + i - (j*j + j)/2).");
   if (ier)
   {
     LOG_ERROR("set_parameter cutoffs");
     return ier;
   }
   ier = modelDriverCreate->SetParameterPointer(
-      numberUniqueSpeciesPairs_, epsilons_, "epsilons");
+      numberUniqueSpeciesPairs_, epsilons_, "epsilons",
+      "Lower-triangular matrix (of size N=" + SNUM(numberModelSpecies_) + ") "
+      "in row-major storage.  Ordering is according to SpeciesCode values.  "
+      "For example, to find the parameter related to SpeciesCode 'i' and "
+      "SpeciesCode 'j' (i >= j), use (zero-based) "
+      "index = (j*N + i - (j*j + j)/2).");
   if (ier)
   {
     LOG_ERROR("set_parameter epsilons");
     return ier;
   }
   ier = modelDriverCreate->SetParameterPointer(
-      numberUniqueSpeciesPairs_, sigmas_, "sigmas");
+      numberUniqueSpeciesPairs_, sigmas_, "sigmas",
+      "Lower-triangular matrix (of size N=" + SNUM(numberModelSpecies_) + ") "
+      "in row-major storage.  Ordering is according to SpeciesCode values.  "
+      "For example, to find the parameter related to SpeciesCode 'i' and "
+      "SpeciesCode 'j' (i >= j), use (zero-based) "
+      "index = (j*N + i - (j*j + j)/2).");
   if (ier)
   {
     LOG_ERROR("set_parameter sigmas");

--- a/examples/model-drivers/ex_model_driver_P_LJ/ex_model_driver_P_LJ.F90
+++ b/examples/model-drivers/ex_model_driver_P_LJ/ex_model_driver_P_LJ.F90
@@ -874,7 +874,8 @@ call kim_model_driver_create_set_model_buffer_pointer( &
 
 ! set pointers to parameters in KIM object
 call kim_model_driver_create_set_parameter_pointer( &
-  model_driver_create_handle, buf%pcutoff, "cutoff", ierr)
+  model_driver_create_handle, buf%pcutoff, "cutoff", &
+  "Distance at which the energy becomes zero.", ierr)
 if (ierr /= 0) then
   kim_log_message = "set_parameter"
   LOG_ERROR()
@@ -883,7 +884,8 @@ if (ierr /= 0) then
 endif
 
 call kim_model_driver_create_set_parameter_pointer( &
-  model_driver_create_handle, buf%epsilon, "epsilon", ierr)
+  model_driver_create_handle, buf%epsilon, "epsilon", &
+  "Energy scale coefficient.", ierr)
 if (ierr /= 0) then
   kim_log_message = "set_parameter"
   LOG_ERROR()
@@ -892,7 +894,8 @@ if (ierr /= 0) then
 endif
 
 call kim_model_driver_create_set_parameter_pointer( &
-  model_driver_create_handle, buf%sigma, "sigma", ierr)
+  model_driver_create_handle, buf%sigma, "sigma", &
+  "Length scale coefficient.", ierr)
 if (ierr /= 0) then
   kim_log_message = "set_parameter"
   LOG_ERROR()

--- a/examples/simulators/ex_test_Ar_fcc_cluster_cpp/ex_test_Ar_fcc_cluster_cpp.cpp
+++ b/examples/simulators/ex_test_Ar_fcc_cluster_cpp/ex_test_Ar_fcc_cluster_cpp.cpp
@@ -255,14 +255,16 @@ int main()
   for (int i=0; i<numberOfParameters; ++i)
   {
     KIM::DataType dataType;
-    std::string const * str;
+    std::string const * strName;
+    std::string const * strDesc;
     int extent;
-    kim_cluster_model->GetParameterDataTypeExtentAndDescription(
-        i, &dataType, &extent, &str);
-    std::cout << "Parameter No. " << i
-              << " has data type \"" << dataType.String() << "\""
-              << " with extent " << extent
-              << " and description : " << *str << std::endl;
+    kim_cluster_model->GetParameterDataTypeExtentNameAndDescription(
+        i, &dataType, &extent, &strName, &strDesc);
+    std::cout << "Parameter No. " << i << " has" << std::endl
+              << " data type   : \"" << dataType.String() << "\"" << std::endl
+              << " extent      : " << extent  << std::endl
+              << " name        : " << *strName << std::endl
+              << " description : " << *strDesc << std::endl;
   }
 
   // We're compatible with the model. Let's do it.

--- a/fortran/include/kim_model_create_module.f90
+++ b/fortran/include/kim_model_create_module.f90
@@ -86,23 +86,25 @@ module kim_model_create_module
 
   interface kim_model_create_set_parameter_pointer
     subroutine kim_model_create_set_parameter_pointer_integer( &
-      model_create_handle, int1, description, ierr)
+      model_create_handle, int1, name, description, ierr)
       use, intrinsic :: iso_c_binding
       import kim_model_create_handle_type
       implicit none
       type(kim_model_create_handle_type), intent(in) :: model_create_handle
       integer(c_int), intent(in), target :: int1(:)
+      character(len=*, kind=c_char), intent(in) :: name
       character(len=*, kind=c_char), intent(in) :: description
       integer(c_int), intent(out) :: ierr
     end subroutine kim_model_create_set_parameter_pointer_integer
 
     subroutine kim_model_create_set_parameter_pointer_double( &
-      model_create_handle, double1, description, ierr)
+      model_create_handle, double1, name, description, ierr)
       use, intrinsic :: iso_c_binding
       import kim_model_create_handle_type
       implicit none
       type(kim_model_create_handle_type), intent(in) :: model_create_handle
       real(c_double), intent(in), target :: double1(:)
+      character(len=*, kind=c_char), intent(in) :: name
       character(len=*, kind=c_char), intent(in) :: description
       integer(c_int), intent(out) :: ierr
     end subroutine kim_model_create_set_parameter_pointer_double

--- a/fortran/include/kim_model_driver_create_module.f90
+++ b/fortran/include/kim_model_driver_create_module.f90
@@ -88,25 +88,27 @@ module kim_model_driver_create_module
 
   interface kim_model_driver_create_set_parameter_pointer
     subroutine kim_model_driver_create_set_parameter_pointer_integer( &
-      model_driver_create_handle, int1, description, ierr)
+      model_driver_create_handle, int1, name, description, ierr)
       use, intrinsic :: iso_c_binding
       import kim_model_driver_create_handle_type
       implicit none
       type(kim_model_driver_create_handle_type), intent(in) &
         :: model_driver_create_handle
       integer(c_int), intent(in), target :: int1(:)
+      character(len=*, kind=c_char), intent(in) :: name
       character(len=*, kind=c_char), intent(in) :: description
       integer(c_int), intent(out) :: ierr
     end subroutine kim_model_driver_create_set_parameter_pointer_integer
 
     subroutine kim_model_driver_create_set_parameter_pointer_double( &
-      model_driver_create_handle, double1, description, ierr)
+      model_driver_create_handle, double1, name, description, ierr)
       use, intrinsic :: iso_c_binding
       import kim_model_driver_create_handle_type
       implicit none
       type(kim_model_driver_create_handle_type), intent(in) &
         :: model_driver_create_handle
       real(c_double), intent(in), target :: double1(:)
+      character(len=*, kind=c_char), intent(in) :: name
       character(len=*, kind=c_char), intent(in) :: description
       integer(c_int), intent(out) :: ierr
     end subroutine kim_model_driver_create_set_parameter_pointer_double

--- a/fortran/include/kim_model_module.f90
+++ b/fortran/include/kim_model_module.f90
@@ -54,7 +54,7 @@ module kim_model_module
     kim_model_clear_then_refresh, &
     kim_model_get_species_support_and_code, &
     kim_model_get_number_of_parameters, &
-    kim_model_get_parameter_data_type_extent_and_description, &
+    kim_model_get_parameter_data_type_extent_name_and_description, &
     kim_model_get_parameter, &
     kim_model_set_parameter, &
     kim_model_set_simulator_buffer_pointer, &
@@ -288,8 +288,8 @@ module kim_model_module
       integer(c_int), intent(out) :: number_of_parameters
     end subroutine kim_model_get_number_of_parameters
 
-    subroutine kim_model_get_parameter_data_type_extent_and_description( &
-      model_handle, index, data_type, extent, description, ierr)
+    subroutine kim_model_get_parameter_data_type_extent_name_and_description( &
+      model_handle, index, data_type, extent, name, description, ierr)
       use, intrinsic :: iso_c_binding
       use :: kim_data_type_module, only : kim_data_type_type
       import kim_model_handle_type
@@ -298,9 +298,10 @@ module kim_model_module
       integer(c_int), intent(in), value :: index
       type(kim_data_type_type), intent(out) :: data_type
       integer(c_int), intent(out) :: extent
+      character(len=*, kind=c_char), intent(out) :: name
       character(len=*, kind=c_char), intent(out) :: description
       integer(c_int), intent(out) :: ierr
-    end subroutine kim_model_get_parameter_data_type_extent_and_description
+    end subroutine kim_model_get_parameter_data_type_extent_name_and_description
 
     subroutine kim_model_set_simulator_buffer_pointer(model_handle, ptr)
       use, intrinsic :: iso_c_binding

--- a/fortran/src/kim_model_create_f.f90
+++ b/fortran/src/kim_model_create_f.f90
@@ -168,7 +168,7 @@ module kim_model_create_f_module
     end function set_species_code
 
     integer(c_int) function set_parameter_pointer_integer( &
-      model_create, extent, ptr, description) &
+      model_create, extent, ptr, name, description) &
       bind(c, name="KIM_ModelCreate_SetParameterPointerInteger")
       use, intrinsic :: iso_c_binding
       import kim_model_create_type
@@ -176,11 +176,12 @@ module kim_model_create_f_module
       type(kim_model_create_type), intent(inout) :: model_create
       integer(c_int), intent(in), value :: extent
       type(c_ptr), intent(in), value :: ptr
+      character(c_char), intent(in) :: name(*)
       character(c_char), intent(in) :: description(*)
     end function set_parameter_pointer_integer
 
     integer(c_int) function set_parameter_pointer_double(model_create, &
-      extent, ptr, description) &
+      extent, ptr, name, description) &
       bind(c, name="KIM_ModelCreate_SetParameterPointerDouble")
       use, intrinsic :: iso_c_binding
       import kim_model_create_type
@@ -188,6 +189,7 @@ module kim_model_create_f_module
       type(kim_model_create_type), intent(inout) :: model_create
       integer(c_int), intent(in), value :: extent
       type(c_ptr), intent(in), value :: ptr
+      character(c_char), intent(in) :: name(*)
       character(c_char), intent(in) :: description(*)
     end function set_parameter_pointer_double
 
@@ -471,24 +473,25 @@ subroutine kim_model_create_set_species_code(model_create_handle, &
 end subroutine kim_model_create_set_species_code
 
 subroutine kim_model_create_set_parameter_pointer_integer( &
-  model_create_handle, int1, description, ierr)
+  model_create_handle, int1, name, description, ierr)
   use, intrinsic :: iso_c_binding
   use kim_model_create_module, only : kim_model_create_handle_type
   use kim_model_create_f_module, only : kim_model_create_type
   implicit none
   type(kim_model_create_handle_type), intent(in) :: model_create_handle
   integer(c_int), intent(in), target :: int1(:)
+  character(len=*, kind=c_char), intent(in) :: name
   character(len=*, kind=c_char), intent(in) :: description
   integer(c_int), intent(out) :: ierr
   type(kim_model_create_type), pointer :: model_create
 
   call c_f_pointer(model_create_handle%p, model_create)
-  call set_parameter(model_create, size(int1, 1, c_int), int1, &
+  call set_parameter(model_create, size(int1, 1, c_int), int1, name, &
     description, ierr)
   return
 
 contains
-  subroutine set_parameter(model_create, extent, int1, description, ierr)
+  subroutine set_parameter(model_create, extent, int1, name, description, ierr)
     use, intrinsic :: iso_c_binding
     use kim_model_create_f_module, only : kim_model_create_type, &
       set_parameter_pointer_integer
@@ -496,33 +499,37 @@ contains
     type(kim_model_create_type), intent(inout) :: model_create
     integer(c_int), intent(in), value :: extent
     integer(c_int), intent(in), target :: int1(extent)
+    character(len=*, kind=c_char), intent(in) :: name
     character(len=*, kind=c_char), intent(in) :: description
     integer(c_int), intent(out) :: ierr
 
     ierr = set_parameter_pointer_integer(model_create, extent, &
-      c_loc(int1), trim(description)//c_null_char)
+      c_loc(int1), trim(name)//c_null_char, &
+      trim(description)//c_null_char)
   end subroutine set_parameter
 end subroutine kim_model_create_set_parameter_pointer_integer
 
 subroutine kim_model_create_set_parameter_pointer_double( &
-  model_create_handle, double1, description, ierr)
+  model_create_handle, double1, name, description, ierr)
   use, intrinsic :: iso_c_binding
   use kim_model_create_module, only : kim_model_create_handle_type
   use kim_model_create_f_module, only : kim_model_create_type
   implicit none
   type(kim_model_create_handle_type), intent(in) :: model_create_handle
   real(c_double), intent(in), target :: double1(:)
+  character(len=*, kind=c_char), intent(in) :: name
   character(len=*, kind=c_char), intent(in) :: description
   integer(c_int), intent(out) :: ierr
   type(kim_model_create_type), pointer :: model_create
 
   call c_f_pointer(model_create_handle%p, model_create)
   call set_parameter(model_create, size(double1, 1, c_int), double1, &
-    description, ierr)
+    name, description, ierr)
   return
 
 contains
-  subroutine set_parameter(model_create, extent, double1, description, ierr)
+  subroutine set_parameter(model_create, extent, double1, name, description, &
+    ierr)
     use, intrinsic :: iso_c_binding
     use kim_model_create_f_module, only : kim_model_create_type, &
       set_parameter_pointer_integer
@@ -530,11 +537,13 @@ contains
     type(kim_model_create_type), intent(inout) :: model_create
     integer(c_int), intent(in), value :: extent
     real(c_double), intent(in), target :: double1(extent)
+    character(len=*, kind=c_char), intent(in) :: name
     character(len=*, kind=c_char), intent(in) :: description
     integer(c_int), intent(out) :: ierr
 
     ierr = set_parameter_pointer_integer(model_create, extent, &
-      c_loc(double1), trim(description)//c_null_char)
+      c_loc(double1), trim(name)//c_null_char, &
+      trim(description)//c_null_char)
   end subroutine set_parameter
 end subroutine kim_model_create_set_parameter_pointer_double
 

--- a/fortran/src/kim_model_driver_create_f.f90
+++ b/fortran/src/kim_model_driver_create_f.f90
@@ -204,7 +204,7 @@ module kim_model_driver_create_f_module
     end function set_species_code
 
     integer(c_int) function set_parameter_pointer_integer( &
-      model_driver_create, extent, ptr, description) &
+      model_driver_create, extent, ptr, name, description) &
       bind(c, name="KIM_ModelDriverCreate_SetParameterPointerInteger")
       use, intrinsic :: iso_c_binding
       import kim_model_driver_create_type
@@ -213,11 +213,12 @@ module kim_model_driver_create_f_module
         :: model_driver_create
       integer(c_int), intent(in), value :: extent
       type(c_ptr), intent(in), value :: ptr
+      character(c_char), intent(in) :: name(*)
       character(c_char), intent(in) :: description(*)
     end function set_parameter_pointer_integer
 
     integer(c_int) function set_parameter_pointer_double( &
-      model_driver_create, extent, ptr, description) &
+      model_driver_create, extent, ptr, name, description) &
       bind(c, name="KIM_ModelDriverCreate_SetParameterPointerDouble")
       use, intrinsic :: iso_c_binding
       import kim_model_driver_create_type
@@ -226,6 +227,7 @@ module kim_model_driver_create_f_module
         :: model_driver_create
       integer(c_int), intent(in), value :: extent
       type(c_ptr), intent(in), value :: ptr
+      character(c_char), intent(in) :: name(*)
       character(c_char), intent(in) :: description(*)
     end function set_parameter_pointer_double
 
@@ -583,7 +585,7 @@ subroutine kim_model_driver_create_set_compute_pointer( &
 end subroutine kim_model_driver_create_set_compute_pointer
 
 subroutine kim_model_driver_create_set_parameter_pointer_integer( &
-  model_driver_create_handle, int1, description, ierr)
+  model_driver_create_handle, int1, name, description, ierr)
   use, intrinsic :: iso_c_binding
   use kim_model_driver_create_module, only &
     : kim_model_driver_create_handle_type
@@ -592,17 +594,18 @@ subroutine kim_model_driver_create_set_parameter_pointer_integer( &
   type(kim_model_driver_create_handle_type), intent(in) &
     :: model_driver_create_handle
   integer(c_int), intent(in), target :: int1(:)
+  character(len=*, kind=c_char), intent(in) :: name
   character(len=*, kind=c_char), intent(in) :: description
   integer(c_int), intent(out) :: ierr
   type(kim_model_driver_create_type), pointer :: model_driver_create
 
   call c_f_pointer(model_driver_create_handle%p, model_driver_create)
   call set_parameter(model_driver_create, size(int1, 1, c_int), int1, &
-    description, ierr)
+    name, description, ierr)
   return
 
 contains
-  subroutine set_parameter(model_driver_create, extent, int1, &
+  subroutine set_parameter(model_driver_create, extent, int1, name, &
     description, ierr)
     use, intrinsic :: iso_c_binding
     use kim_model_driver_create_f_module, only &
@@ -614,16 +617,18 @@ contains
       :: model_driver_create
     integer(c_int), intent(in), value :: extent
     integer(c_int), intent(in), target :: int1(extent)
+    character(len=*, kind=c_char), intent(in) :: name
     character(len=*, kind=c_char), intent(in) :: description
     integer(c_int), intent(out) :: ierr
 
     ierr = set_parameter_pointer_integer(model_driver_create, extent, &
-      c_loc(int1), trim(description)//c_null_char)
+      c_loc(int1), trim(name)//c_null_char, &
+      trim(description)//c_null_char)
   end subroutine set_parameter
 end subroutine kim_model_driver_create_set_parameter_pointer_integer
 
 subroutine kim_model_driver_create_set_parameter_pointer_double( &
-  model_driver_create_handle, double1, description, ierr)
+  model_driver_create_handle, double1, name, description, ierr)
   use, intrinsic :: iso_c_binding
   use kim_model_driver_create_module, only &
     : kim_model_driver_create_handle_type
@@ -632,18 +637,19 @@ subroutine kim_model_driver_create_set_parameter_pointer_double( &
   type(kim_model_driver_create_handle_type), intent(in) &
     :: model_driver_create_handle
   real(c_double), intent(in), target :: double1(:)
+  character(len=*, kind=c_char), intent(in) :: name
   character(len=*, kind=c_char), intent(in) :: description
   integer(c_int), intent(out) :: ierr
   type(kim_model_driver_create_type), pointer :: model_driver_create
 
   call c_f_pointer(model_driver_create_handle%p, model_driver_create)
   call set_parameter(model_driver_create, size(double1, 1, c_int), &
-    double1, description, ierr)
+    double1, name, description, ierr)
   return
 
 contains
   subroutine set_parameter(model_driver_create, extent, double1, &
-    description, ierr)
+    name, description, ierr)
     use, intrinsic :: iso_c_binding
     use kim_model_driver_create_f_module, only &
       : kim_model_driver_create_type
@@ -654,11 +660,13 @@ contains
       :: model_driver_create
     integer(c_int), intent(in), value :: extent
     real(c_double), intent(in), target :: double1(extent)
+    character(len=*, kind=c_char), intent(in) :: name
     character(len=*, kind=c_char), intent(in) :: description
     integer(c_int), intent(out) :: ierr
 
     ierr = set_parameter_pointer_double(model_driver_create, extent, &
-      c_loc(double1), trim(description)//c_null_char)
+      c_loc(double1), trim(name)//c_null_char, &
+      trim(description)//c_null_char)
   end subroutine set_parameter
 end subroutine kim_model_driver_create_set_parameter_pointer_double
 


### PR DESCRIPTION
@dschopf @tadmor  @schiotz @mjwen

I've implemented the parameter name string in this branch.  Before I merge it, I would like to have you all look over it so see if we are happy with it.  The LennardJones612 and ex_model_Ar_P_LJ are the two models that publish their parameters.  The ex_test_Ar_fcc_cluster_cpp examle simulator retreives the parameter information and displays it.

Please leave comments/approval in this pull-request.  Thanks.