### PR TITLE
Fixing the failure when sourcing the environment from zsh.

### DIFF
--- a/utils/activate.in
+++ b/utils/activate.in
@@ -35,12 +35,21 @@
 
 
 # Ensure that this script is sourced, not executed
-if test x"`basename "$0" 2> /dev/null`" \
-        = x"@PROJECT_NAME@-activate"; then
-  (>&2 printf "Error:\t@PROJECT_NAME@-activate must be sourced.\n"
-   printf "\tRun 'source @PROJECT_NAME@-activate' not "
-   printf "'@PROJECT_NAME@-activate'.\n")
-  exit 1
+BASENAME_SOURCE=`basename -- "$0" 2> /dev/null`
+
+if test -n "$ZSH_VERSION"; then
+    if test $options[posixargzero] != "on"; then
+        setopt posixargzero
+        BASENAME_SOURCE=`basename -- "$0" 2> /dev/null`
+        setopt posixargzero
+    fi
+fi
+
+if test x"${BASENAME_SOURCE}" = x"@PROJECT_NAME@-activate"; then
+    (>&2 printf "\nError:\t@PROJECT_NAME@-activate must be sourced.\n"
+    printf "\tRun 'source @PROJECT_NAME@-activate' not "
+    printf "'@PROJECT_NAME@-activate'.\n")
+    exit 1
 fi
 
 export PATH="@CMAKE_INSTALL_FULL_BINDIR@:${PATH}"

--- a/utils/activate.in
+++ b/utils/activate.in
@@ -38,18 +38,18 @@
 BASENAME_SOURCE=`basename -- "$0" 2> /dev/null`
 
 if test -n "$ZSH_VERSION"; then
-    if test $options[posixargzero] != "on"; then
-        setopt posixargzero
-        BASENAME_SOURCE=`basename -- "$0" 2> /dev/null`
-        setopt posixargzero
-    fi
+  if test $options[posixargzero] != "on"; then
+    setopt posixargzero
+    BASENAME_SOURCE=`basename -- "$0" 2> /dev/null`
+    setopt posixargzero
+  fi
 fi
 
 if test x"${BASENAME_SOURCE}" = x"@PROJECT_NAME@-activate"; then
-    (>&2 printf "\nError:\t@PROJECT_NAME@-activate must be sourced.\n"
-    printf "\tRun 'source @PROJECT_NAME@-activate' not "
-    printf "'@PROJECT_NAME@-activate'.\n")
-    exit 1
+  (>&2 printf "\nError:\t@PROJECT_NAME@-activate must be sourced.\n"
+   printf "\tRun 'source @PROJECT_NAME@-activate' not "
+   printf "'@PROJECT_NAME@-activate'.\n")
+  exit 1
 fi
 
 export PATH="@CMAKE_INSTALL_FULL_BINDIR@:${PATH}"

--- a/utils/deactivate.in
+++ b/utils/deactivate.in
@@ -35,14 +35,22 @@
 
 
 # Ensure that this script is sourced, not executed
-if test x"`basename "$0" 2> /dev/null`" \
-        = x"@PROJECT_NAME@-deactivate"; then
-  (>&2 printf "Error:\t@PROJECT_NAME@-deactivate must be sourced.\n"
-   printf "\tRun 'source @PROJECT_NAME@-deactivate' not "
-   printf "'@PROJECT_NAME@-deactivate'.\n")
-  exit 1
+BASENAME_SOURCE=`basename -- "$0" 2> /dev/null`
+
+if test -n "$ZSH_VERSION"; then
+    if test $options[posixargzero] != "on"; then
+        setopt posixargzero
+        BASENAME_SOURCE=`basename -- "$0" 2> /dev/null`
+        setopt posixargzero
+    fi
 fi
 
+if test x"${BASENAME_SOURCE}" = x"@PROJECT_NAME@-deactivate"; then
+    (>&2 printf "\nError:\t@PROJECT_NAME@-deactivate must be sourced.\n"
+    printf "\tRun 'source @PROJECT_NAME@-deactivate' not "
+    printf "'@PROJECT_NAME@-deactivate'.\n")
+    exit 1
+fi
 
 export PATH=`printf "${PATH}" | sed -e "s|:@CMAKE_INSTALL_FULL_BINDIR@|:|g" \
                                     -e "s|^@CMAKE_INSTALL_FULL_BINDIR@:*||" \

--- a/utils/deactivate.in
+++ b/utils/deactivate.in
@@ -38,18 +38,18 @@
 BASENAME_SOURCE=`basename -- "$0" 2> /dev/null`
 
 if test -n "$ZSH_VERSION"; then
-    if test $options[posixargzero] != "on"; then
-        setopt posixargzero
-        BASENAME_SOURCE=`basename -- "$0" 2> /dev/null`
-        setopt posixargzero
-    fi
+  if test $options[posixargzero] != "on"; then
+    setopt posixargzero
+    BASENAME_SOURCE=`basename -- "$0" 2> /dev/null`
+    setopt posixargzero
+  fi
 fi
 
 if test x"${BASENAME_SOURCE}" = x"@PROJECT_NAME@-deactivate"; then
-    (>&2 printf "\nError:\t@PROJECT_NAME@-deactivate must be sourced.\n"
-    printf "\tRun 'source @PROJECT_NAME@-deactivate' not "
-    printf "'@PROJECT_NAME@-deactivate'.\n")
-    exit 1
+  (>&2 printf "\nError:\t@PROJECT_NAME@-deactivate must be sourced.\n"
+   printf "\tRun 'source @PROJECT_NAME@-deactivate' not "
+   printf "'@PROJECT_NAME@-deactivate'.\n")
+  exit 1
 fi
 
 export PATH=`printf "${PATH}" | sed -e "s|:@CMAKE_INSTALL_FULL_BINDIR@|:|g" \


### PR DESCRIPTION
A minor solution on LINUX and MAC using zsh, esp when installing Kim-API locally.
In zsh, the value of $0 depends on the FUNCTION_ARGZERO option, which is set by default and temporarily sets the $0 to the name of the function or script when sourcing a script. To fix this problem on zsh, we can use POSIX_ARGZERO which exposes the value of $0 in spite of the current FUNCTION_ARGZERO setting.