### PR TITLE
See text as code block

### DIFF
--- a/cpp/src/edn-cpp/README.md
+++ b/cpp/src/edn-cpp/README.md
@@ -60,6 +60,7 @@ If you define DEBUG you will see debug output when using pprint. This looks like
 Which is nice when proving things are parsing as you expect. 
 
 ##api
+
 	list<EdnToken> lex(string ednString)
 	
 	EdnNode read(string ednString)
@@ -87,6 +88,7 @@ Which is nice when proving things are parsing as you expect.
 	EdnNode handleTagged(EdnToken token, EdnNode value)
 	
 ##structs
+
 	EdnToken
 		TokenType type
 		int line
@@ -99,6 +101,7 @@ Which is nice when proving things are parsing as you expect.
 		list<EdnNode> values #used for collections
 		
 ##enums
+
 	TokenType
 		TokenString
 		TokenAtom


### PR DESCRIPTION
When using doxygen as documentation engine.
In case in a paragraph a code block is requested, this can be accomplished by means of some indentation relative to the previous text in the paragraph. A problem occurs when there is no previous text (e.g. paragraph 'api') to get the code just insert an empty line in the beginning of such a paragraph.