### PR TITLE
Devel

### DIFF
--- a/c/src/KIM_Collections_c.cpp
+++ b/c/src/KIM_Collections_c.cpp
@@ -106,7 +106,11 @@ int KIM_Collections_Create(KIM_Collections ** const collections)
   KIM::Collections * pCollections;
   int error = KIM::Collections::Create(&pCollections);
 
-  if (error) { return true; }
+  if (error)
+  {
+    *collections = NULL;
+    return true;
+  }
   else
   {
     (*collections) = new KIM_Collections;
@@ -117,10 +121,13 @@ int KIM_Collections_Create(KIM_Collections ** const collections)
 
 void KIM_Collections_Destroy(KIM_Collections ** const collections)
 {
-  KIM::Collections * pCollections
-      = reinterpret_cast<KIM::Collections *>((*collections)->p);
+  if (*collections)
+  {
+    KIM::Collections * pCollections
+        = reinterpret_cast<KIM::Collections *>((*collections)->p);
 
-  KIM::Collections::Destroy(&pCollections);
+    KIM::Collections::Destroy(&pCollections);
+  }
   delete (*collections);
   *collections = NULL;
 }
@@ -151,7 +158,10 @@ int KIM_Collections_GetItemLibraryFileNameAndCollection(
       &pStrFileName,
       reinterpret_cast<KIM::Collection *>(collection));
   if (error)
+  {
+    *fileName = NULL;
     return true;
+  }
   else
   {
     *fileName = pStrFileName->c_str();
@@ -203,17 +213,16 @@ int KIM_Collections_GetItemMetadataFile(
                                                 availableAsString,
                                                 ppStrFileString);
   if (error)
+  {
+    if (fileName) *fileName = NULL;
+    if (fileString) *fileString = NULL;
     return true;
+  }
   else
   {
-    if (fileName != NULL) *fileName = pStrFileName->c_str();
-    if (fileString != NULL)
-    {
-      if (pStrFileString == NULL)
-        *fileString = NULL;
-      else
-        *fileString = pStrFileString->c_str();
-    }
+    if (fileName) *fileName = pStrFileName ? pStrFileName->c_str() : NULL;
+    if (fileString)
+      *fileString = pStrFileString ? pStrFileString->c_str() : NULL;
     return false;
   }
 }
@@ -237,11 +246,15 @@ int KIM_Collections_GetItemMetadataFile_fortran(
                                                   availableAsString,
                                                   fileString);
   if (error)
+  {
+    *fileLength = NULL;
     return true;
+  }
   else if ((sizeof(int) == sizeof(long)) && (uFileLength > INT_MAX))
   {
     std::cerr << "* Error : long overflow for fileLength. " << __FILE__ << ":"
               << __LINE__ << std::endl;
+    *fileLength = NULL;
     return true;
   }
   else
@@ -272,10 +285,13 @@ int KIM_Collections_GetItemNameByType(KIM_Collections * const collections,
   std::string const * pStrItemName;
   int error = pCollections->GetItemNameByType(index, &pStrItemName);
   if (error)
+  {
+    *itemName = NULL;
     return true;
+  }
   else
   {
-    *itemName = pStrItemName->c_str();
+    *itemName = pStrItemName ? pStrItemName->c_str() : NULL;
     return false;
   }
 }
@@ -303,10 +319,13 @@ int KIM_Collections_GetItemNameByCollectionAndType(
   int error
       = pCollections->GetItemNameByCollectionAndType(index, &pStrItemName);
   if (error)
+  {
+    *itemName = NULL;
     return true;
+  }
   else
   {
-    *itemName = pStrItemName->c_str();
+    *itemName = pStrItemName ? pStrItemName->c_str() : NULL;
     return false;
   }
 }
@@ -327,10 +346,13 @@ int KIM_Collections_GetItemLibraryFileNameByCollectionAndType(
       itemName,
       &pStrFileName);
   if (error)
+  {
+    *itemName = NULL;
     return true;
+  }
   else
   {
-    *fileName = pStrFileName->c_str();
+    *fileName = pStrFileName ? pStrFileName->c_str() : NULL;
     return false;
   }
 }
@@ -384,17 +406,16 @@ int KIM_Collections_GetItemMetadataFileByCollectionAndType(
                                                              availableAsString,
                                                              ppStrFileString);
   if (error)
+  {
+    if (fileName) *fileName = NULL;
+    if (fileString) *fileString = NULL;
     return true;
+  }
   else
   {
-    if (fileName != NULL) *fileName = pStrFileName->c_str();
-    if (fileString != NULL)
-    {
-      if (pStrFileString == NULL)
-        *fileString = NULL;
-      else
-        *fileString = pStrFileString->c_str();
-    }
+    if (fileName) *fileName = pStrFileName ? pStrFileName->c_str() : NULL;
+    if (fileString)
+      *fileString = pStrFileString ? pStrFileString->c_str() : NULL;
     return false;
   }
 }
@@ -419,11 +440,15 @@ int KIM_Collections_GetItemMetadataFileByCollectionAndType_fortran(
       availableAsString,
       fileString);
   if (error)
+  {
+    *fileLength = NULL;
     return true;
+  }
   else if ((sizeof(int) == sizeof(long)) && (uFileLength > INT_MAX))
   {
     std::cerr << "* Error : long overflow for fileLength. " << __FILE__ << ":"
               << __LINE__ << std::endl;
+    *fileLength = NULL;
     return true;
   }
   else
@@ -456,8 +481,9 @@ void KIM_Collections_GetProjectNameAndSemVer(
     ppStrSemVer = &pStrSemVer;
 
   pCollections->GetProjectNameAndSemVer(ppStrProjectName, ppStrSemVer);
-  if (projectName != NULL) *projectName = pStrProjectName->c_str();
-  if (semVer != NULL) *semVer = pStrSemVer->c_str();
+  if (projectName)
+    *projectName = pStrProjectName ? pStrProjectName->c_str() : NULL;
+  if (semVer) *semVer = pStrSemVer ? pStrSemVer->c_str() : NULL;
 }
 
 int KIM_Collections_GetEnvironmentVariableName(
@@ -471,10 +497,13 @@ int KIM_Collections_GetEnvironmentVariableName(
   int error = pCollections->GetEnvironmentVariableName(
       makeItemTypeCpp(itemType), &pStrName);
   if (error)
+  {
+    *name = NULL;
     return true;
+  }
   else
   {
-    *name = pStrName->c_str();
+    *name = pStrName ? pStrName->c_str() : NULL;
     return false;
   }
 }
@@ -502,8 +531,8 @@ void KIM_Collections_GetConfigurationFileEnvironmentVariable(
 
   pCollections->GetConfigurationFileEnvironmentVariable(ppStrName, ppStrValue);
 
-  if (name != NULL) *name = pStrName->c_str();
-  if (value != NULL) *value = pStrValue->c_str();
+  if (name) *name = pStrName ? pStrName->c_str() : NULL;
+  if (value) *value = pStrValue ? pStrValue->c_str() : NULL;
 }
 
 void KIM_Collections_GetConfigurationFileName(
@@ -513,7 +542,7 @@ void KIM_Collections_GetConfigurationFileName(
 
   std::string const * pStrFileName;
   pCollections->GetConfigurationFileName(&pStrFileName);
-  *fileName = pStrFileName->c_str();
+  *fileName = pStrFileName ? pStrFileName->c_str() : NULL;
 }
 
 int KIM_Collections_CacheListOfDirectoryNames(
@@ -537,10 +566,13 @@ int KIM_Collections_GetDirectoryName(KIM_Collections * const collections,
   std::string const * pStrDirectoryName;
   int error = pCollections->GetDirectoryName(index, &pStrDirectoryName);
   if (error)
+  {
+    *directoryName = NULL;
     return true;
+  }
   else
   {
-    *directoryName = pStrDirectoryName->c_str();
+    *directoryName = pStrDirectoryName ? pStrDirectoryName->c_str() : NULL;
     return true;
   }
 }

--- a/c/src/KIM_Log_c.cpp
+++ b/c/src/KIM_Log_c.cpp
@@ -72,7 +72,11 @@ int KIM_Log_Create(KIM_Log ** const log)
 {
   KIM::Log * pLog;
   int error = KIM::Log::Create(&pLog);
-  if (error) { return true; }
+  if (error)
+  {
+    *log = NULL;
+    return true;
+  }
   else
   {
     (*log) = new KIM_Log;
@@ -83,9 +87,12 @@ int KIM_Log_Create(KIM_Log ** const log)
 
 void KIM_Log_Destroy(KIM_Log ** const log)
 {
-  KIM::Log * pLog = reinterpret_cast<KIM::Log *>((*log)->p);
+  if (*log)
+  {
+    KIM::Log * pLog = reinterpret_cast<KIM::Log *>((*log)->p);
 
-  KIM::Log::Destroy(&pLog);
+    KIM::Log::Destroy(&pLog);
+  }
   delete (*log);
   *log = NULL;
 }

--- a/c/src/KIM_ModelDriverCreate_c.cpp
+++ b/c/src/KIM_ModelDriverCreate_c.cpp
@@ -186,7 +186,10 @@ int KIM_ModelDriverCreate_GetParameterFileName(
   int error = pModelDriverCreate->GetParameterFileName(index, ppStr);
 
   if (error)
+  {
+    if (parameterFileName) *parameterFileName = NULL;
     return true;
+  }
   else
   {
     if (parameterFileName != NULL) *parameterFileName = pStr->c_str();

--- a/c/src/KIM_Model_c.cpp
+++ b/c/src/KIM_Model_c.cpp
@@ -196,7 +196,11 @@ int KIM_Model_Create(KIM_Numbering const numbering,
                                modelNameC,
                                requestedUnitsAccepted,
                                &pModel);
-  if (err) { return true; }
+  if (err)
+  {
+    *model = NULL;
+    return true;
+  }
   else
   {
     (*model) = new KIM_Model;
@@ -207,9 +211,12 @@ int KIM_Model_Create(KIM_Numbering const numbering,
 
 void KIM_Model_Destroy(KIM_Model ** const model)
 {
-  KIM::Model * pModel = reinterpret_cast<KIM::Model *>((*model)->p);
+  if (*model)
+  {
+    KIM::Model * pModel = reinterpret_cast<KIM::Model *>((*model)->p);
 
-  KIM::Model::Destroy(&pModel);
+    KIM::Model::Destroy(&pModel);
+  }
   delete (*model);
   *model = NULL;
 }
@@ -272,7 +279,11 @@ int KIM_Model_ComputeArgumentsCreate(
   KIM::ComputeArguments * pComputeArguments;
 
   int err = pModel->ComputeArgumentsCreate(&pComputeArguments);
-  if (err) { return true; }
+  if (err)
+  {
+    *computeArguments = NULL;
+    return true;
+  }
   else
   {
     (*computeArguments) = new KIM_ComputeArguments;
@@ -287,17 +298,17 @@ int KIM_Model_ComputeArgumentsDestroy(
 {
   CONVERT_POINTER;
 
-  KIM::ComputeArguments * pComputeArguments
-      = reinterpret_cast<KIM::ComputeArguments *>((*computeArguments)->p);
-
-  int err = pModel->ComputeArgumentsDestroy(&pComputeArguments);
-  if (err) { return true; }
-  else
+  int err = false;
+  if (*computeArguments)
   {
-    delete (*computeArguments);
-    *computeArguments = NULL;
-    return false;
+    KIM::ComputeArguments * pComputeArguments
+        = reinterpret_cast<KIM::ComputeArguments *>((*computeArguments)->p);
+
+    err = pModel->ComputeArgumentsDestroy(&pComputeArguments);
   }
+  delete (*computeArguments);
+  *computeArguments = NULL;
+  return err;
 }
 
 int KIM_Model_Compute(KIM_Model const * const model,
@@ -390,7 +401,12 @@ int KIM_Model_GetParameterMetadata(KIM_Model const * const model,
       parameterIndex, pTyp, extent, ppStrName, ppStrDesc);
 
   if (error)
+  {
+    if (dataType) *dataType = NULL;
+    if (name) *name = NULL;
+    if (description) *description = NULL;
     return true;
+  }
   else
   {
     if (dataType != NULL) *dataType = makeDataTypeC(typ);

--- a/c/src/KIM_SimulatorModel_c.cpp
+++ b/c/src/KIM_SimulatorModel_c.cpp
@@ -75,7 +75,11 @@ int KIM_SimulatorModel_Create(char const * const simulatorModelName,
   KIM::SimulatorModel * pSimulatorModel;
   int error
       = KIM::SimulatorModel::Create(simulatorModelNameC, &pSimulatorModel);
-  if (error) { return true; }
+  if (error)
+  {
+    *simulatorModel = NULL;
+    return true;
+  }
   else
   {
     (*simulatorModel) = new KIM_SimulatorModel;
@@ -86,10 +90,13 @@ int KIM_SimulatorModel_Create(char const * const simulatorModelName,
 
 void KIM_SimulatorModel_Destroy(KIM_SimulatorModel ** const simulatorModel)
 {
-  KIM::SimulatorModel * pSimulatorModel
-      = reinterpret_cast<KIM::SimulatorModel *>((*simulatorModel)->p);
+  if (*simulatorModel)
+  {
+    KIM::SimulatorModel * pSimulatorModel
+        = reinterpret_cast<KIM::SimulatorModel *>((*simulatorModel)->p);
 
-  KIM::SimulatorModel::Destroy(&pSimulatorModel);
+    KIM::SimulatorModel::Destroy(&pSimulatorModel);
+  }
   delete (*simulatorModel);
   *simulatorModel = NULL;
 }
@@ -141,7 +148,10 @@ int KIM_SimulatorModel_GetSupportedSpecies(
   std::string const * pStrSpecies;
   int error = pSimulatorModel->GetSupportedSpecies(index, &pStrSpecies);
   if (error)
+  {
+    *speciesName = NULL;
     return true;
+  }
   else
   {
     *speciesName = pStrSpecies->c_str();
@@ -210,7 +220,10 @@ int KIM_SimulatorModel_GetSimulatorFieldMetadata(
   int error = pSimulatorModel->GetSimulatorFieldMetadata(
       fieldIndex, extent, ppStrFieldName);
   if (error)
+  {
+    if (fieldName) *fieldName = NULL;
     return true;
+  }
   else
   {
     if (fieldName != NULL) *fieldName = pStrFieldName->c_str();
@@ -230,7 +243,10 @@ int KIM_SimulatorModel_GetSimulatorFieldLine(
   int error = pSimulatorModel->GetSimulatorFieldLine(
       fieldIndex, lineIndex, &pStrLineValue);
   if (error)
+  {
+    *lineValue = NULL;
     return true;
+  }
   else
   {
     *lineValue = pStrLineValue->c_str();
@@ -280,7 +296,10 @@ int KIM_SimulatorModel_GetParameterFileName(
   int error
       = pSimulatorModel->GetParameterFileName(index, &pStrParameterFileName);
   if (error)
+  {
+    *parameterFileName = NULL;
     return true;
+  }
   else
   {
     *parameterFileName = pStrParameterFileName->c_str();

--- a/c/src/KIM_SimulatorModel_c.cpp
+++ b/c/src/KIM_SimulatorModel_c.cpp
@@ -214,7 +214,7 @@ int KIM_SimulatorModel_GetSimulatorFieldMetadata(
   else
   {
     if (fieldName != NULL) *fieldName = pStrFieldName->c_str();
-    return true;
+    return false;
   }
 }
 

--- a/cpp/src/KIM_LogImplementation.cpp
+++ b/cpp/src/KIM_LogImplementation.cpp
@@ -221,9 +221,7 @@ void LogImplementation::LogEntry(LogVerbosity const logVerbosity,
 }
 
 LogImplementation::LogImplementation() :
-    idString_(SPTR(this)),
-    latestTimeStamp_(""),
-    sequence_(0)
+    idString_(SPTR(this)), latestTimeStamp_(""), sequence_(0)
 {
   verbosity_.push(defaultLogVerbosity.top());
 }

--- a/cpp/src/KIM_Model.cpp
+++ b/cpp/src/KIM_Model.cpp
@@ -76,7 +76,7 @@ int Model::Create(Numbering const numbering,
 
 void Model::Destroy(Model ** const model)
 {
-  ModelImplementation::Destroy(&((*model)->pimpl));
+  if (*model) { ModelImplementation::Destroy(&((*model)->pimpl)); }
   delete *model;
   *model = NULL;
 }

--- a/cpp/src/KIM_ModelImplementation.cpp
+++ b/cpp/src/KIM_ModelImplementation.cpp
@@ -268,7 +268,11 @@ int ModelImplementation::Create(
 
   Log * pLog;
   int error = Log::Create(&pLog);
-  if (error) { return true; }
+  if (error)
+  {
+    *modelImplementation = NULL;
+    return true;
+  }
 
   ModelImplementation * pModelImplementation;
   pModelImplementation = new ModelImplementation(new SharedLibrary(pLog), pLog);
@@ -300,7 +304,7 @@ int ModelImplementation::Create(
         __FILE__);
 #endif
     delete pModelImplementation;  // also deletes pLog
-
+    *modelImplementation = NULL;
     return true;
   }
   col->SetLogID(pLog->GetID() + "_Collections");
@@ -324,7 +328,7 @@ int ModelImplementation::Create(
         __FILE__);
 #endif
     delete pModelImplementation;  // also deletes pLog and collections object
-
+    *modelImplementation = NULL;
     return true;
   }
 
@@ -374,22 +378,26 @@ int ModelImplementation::Create(
 void ModelImplementation::Destroy(
     ModelImplementation ** const modelImplementation)
 {
+  if (*modelImplementation)
+  {
 #if DEBUG_VERBOSITY
-  std::string callString = "Destroy(" + SPTR(modelImplementation) + ").";
-  (*modelImplementation)
-      ->LogEntry(
-          LOG_VERBOSITY::debug, "Enter  " + callString, __LINE__, __FILE__);
+    std::string callString = "Destroy(" + SPTR(modelImplementation) + ").";
+    (*modelImplementation)
+        ->LogEntry(
+            LOG_VERBOSITY::debug, "Enter  " + callString, __LINE__, __FILE__);
 #endif
 
-  (*modelImplementation)->ModelDestroy();
+    (*modelImplementation)->ModelDestroy();
 
 #if DEBUG_VERBOSITY
-  (*modelImplementation)
-      ->LogEntry(LOG_VERBOSITY::debug,
-                 "Destroying ModelImplementation object and exit " + callString,
-                 __LINE__,
-                 __FILE__);
+    (*modelImplementation)
+        ->LogEntry(LOG_VERBOSITY::debug,
+                   "Destroying ModelImplementation object and exit "
+                       + callString,
+                   __LINE__,
+                   __FILE__);
 #endif
+  }
   delete *modelImplementation;  // also deletes Log & collections objects
   *modelImplementation = NULL;
 }

--- a/cpp/src/KIM_SimulatorModel.cpp
+++ b/cpp/src/KIM_SimulatorModel.cpp
@@ -62,7 +62,8 @@ int SimulatorModel::Create(std::string const & simulatorModelName,
 
 void SimulatorModel::Destroy(SimulatorModel ** const simulatorModel)
 {
-  SimulatorModelImplementation::Destroy(&((*simulatorModel)->pimpl));
+  if (*simulatorModel)
+  { SimulatorModelImplementation::Destroy(&((*simulatorModel)->pimpl)); }
   delete *simulatorModel;
   *simulatorModel = NULL;
 }

--- a/cpp/src/KIM_SimulatorModelImplementation.cpp
+++ b/cpp/src/KIM_SimulatorModelImplementation.cpp
@@ -86,7 +86,11 @@ int SimulatorModelImplementation::Create(
 
   Log * pLog;
   int error = Log::Create(&pLog);
-  if (error) { return true; }
+  if (error)
+  {
+    *simulatorModelImplementation = NULL;
+    return true;
+  }
 
   SimulatorModelImplementation * pSimulatorModelImplementation;
   pSimulatorModelImplementation
@@ -114,7 +118,7 @@ int SimulatorModelImplementation::Create(
         __FILE__);
 #endif
     delete pSimulatorModelImplementation;  // also deletes pLog
-
+    *simulatorModelImplementation = NULL;
     return true;
   }
   col->SetLogID(pLog->GetID() + "_Collections");
@@ -133,7 +137,7 @@ int SimulatorModelImplementation::Create(
 #endif
     delete pSimulatorModelImplementation;  // also deletes Log object and
                                            // collections object
-
+    *simulatorModelImplementation = NULL;
     return true;
   }
 


### PR DESCRIPTION
Explicitly initialize the pointers passing through create, and destroy class instances, to prevent used-before-set errors and their associated undefined behavior in an unpredicted behavior or mistakes.