### PR TITLE
Update the parameter file data names

### DIFF
--- a/cpp/src/KIM_ModelImplementation.cpp
+++ b/cpp/src/KIM_ModelImplementation.cpp
@@ -3159,30 +3159,35 @@ int ModelImplementation::WriteParameterFiles()
   LOG_DEBUG("Enter  " + callString);
 
   sharedLibrary_->GetNumberOfParameterFiles(&numberOfParameterFiles_);
+  std::vector<std::string> parameterFileNameBase;
   std::vector<unsigned char const *> parameterFileStrings;
   std::vector<unsigned int> parameterFileStringLengths;
   for (int i = 0; i < numberOfParameterFiles_; ++i)
   {
+    std::string parameterFileName;
     unsigned char const * strPtr;
     unsigned int length;
-    int error = sharedLibrary_->GetParameterFile(i, NULL, &length, &strPtr);
+    int error = sharedLibrary_->GetParameterFile(i, 
+                                                 &parameterFileName, 
+                                                 &length, 
+                                                 &strPtr);
     if (error)
     {
       LOG_ERROR("Could not get parameter file data.");
       LOG_DEBUG("Exit 1=" + callString);
       return true;
     }
+    parameterFileNameBase.push_back(parameterFileName + "-XXXXXXXXXXXX");
     parameterFileStrings.push_back(strPtr);
     parameterFileStringLengths.push_back(length);
   }
 
-  static char const fileNameString[] = "kim-model-parameter-file-XXXXXXXXXXXX";
   for (int i = 0; i < numberOfParameterFiles_; ++i)
   {
     std::stringstream templateString;
     templateString << P_tmpdir
                    << ((*(--(std::string(P_tmpdir).end())) == '/') ? "" : "/")
-                   << fileNameString;
+                   << parameterFileNameBase[i];
     char * cstr = strdup(templateString.str().c_str());
     int fileid = mkstemp(cstr);
     if (fileid == -1)


### PR DESCRIPTION
- Summary
This pull request is updating the parameter file data names to enable users to extract the
original parameter file names or inquire their names from the created name and being backward compatible.
In the previous implementation, all parameter files are saved as `"kim-model-parameter-file-XXXXXXXXXXXX";` which does not allow to extract the original file name from the created name.
This pull request includes the new naming strategy, where the parameter files are saved as `parameterFileName + "-XXXXXXXXXXXX"` which enables the user to extract the original filename if it is needed. 
e.g in C++ <br />
to get the original filename, one can do:
    ```cpp
  std::string::size_type n1 = filename.rfind('/');
  if (n1 == std::string::npos) n1 = 0;
  else n1 += 1;
  std::string::size_type n2 = filename.length() - 13 - n1;
  parameterFileName = filename.substr(n1, n2)
    ``` 
    to check if the KIM provided parameter file is the same as the original file, one can do:
    ```cpp
  std::string::size_type n = filename.find(ParameterFileName);
  bool isSame = (n != std::string::npos)
    ```
- Backward Compatibility
No known issues