### PR TITLE
SimulatorModel and ModelDriverCreate API additions and deprecations for param file processing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,7 +69,7 @@ mark_as_advanced(KIM_API_ENABLE_COVERAGE)
 #
 # Define main project
 #
-project(${KIM_API_PROJECT_NAME} VERSION 2.1.4 LANGUAGES CXX C Fortran)  # must remain a single line for create-pacakge script
+project(${KIM_API_PROJECT_NAME} VERSION 2.2.0 LANGUAGES CXX C Fortran)  # must remain a single line for create-pacakge script
 set(PROJECT_DESCRIPTION "An Application Programming Interface (API) for the Knowledgebase of Interatomic Models (KIM).")
 include(GNUInstallDirs)  # needs to come after call to project()
 include(CompletionConfig)  # set install dirs for completions

--- a/c/include/KIM_ModelDriverCreate.h
+++ b/c/include/KIM_ModelDriverCreate.h
@@ -157,6 +157,18 @@ typedef struct KIM_ModelDriverCreate KIM_ModelDriverCreate;
 
 
 /**
+ ** \brief \copybrief KIM::ModelDriverCreate::GetParameterFileDirectoryName
+ **
+ ** \sa KIM::ModelDriverCreate::GetParameterFileDirectoryName,
+ ** kim_model_driver_create_module::kim_get_parameter_file_directory_name
+ **
+ ** \since 2.2
+ **/
+void KIM_ModelDriverCreate_GetParameterFileDirectoryName(
+    KIM_ModelDriverCreate const * const modelDriverCreate,
+    char const ** const directoryName);
+
+/**
  ** \brief \copybrief KIM::ModelDriverCreate::GetNumberOfParameterFiles
  **
  ** \sa KIM::ModelDriverCreate::GetNumberOfParameterFiles,
@@ -175,11 +187,27 @@ void KIM_ModelDriverCreate_GetNumberOfParameterFiles(
  ** kim_model_driver_create_module::kim_get_parameter_file_name
  **
  ** \since 2.0
+ **
+ ** \deprecated As of 2.2.  Please use
+ ** KIM_ModelDriverCreate_GetParameterFileBasename() instead.
  **/
 int KIM_ModelDriverCreate_GetParameterFileName(
     KIM_ModelDriverCreate const * const modelDriverCreate,
     int const index,
     char const ** const parameterFileName);
+
+/**
+ ** \brief \copybrief KIM::ModelDriverCreate::GetParameterFileBasename
+ **
+ ** \sa KIM::ModelDriverCreate::GetParameterFileBasename,
+ ** kim_model_driver_create_module::kim_get_parameter_file_basename
+ **
+ ** \since 2.2
+ **/
+int KIM_ModelDriverCreate_GetParameterFileBasename(
+    KIM_ModelDriverCreate const * const modelDriverCreate,
+    int const index,
+    char const ** const parameterFileBasename);
 
 /**
  ** \brief \copybrief KIM::ModelDriverCreate::SetModelNumbering

--- a/c/include/KIM_SimulatorModel.h
+++ b/c/include/KIM_SimulatorModel.h
@@ -247,11 +247,27 @@ void KIM_SimulatorModel_GetNumberOfParameterFiles(
  ** kim_simulator_model_module::kim_get_parameter_file_name
  **
  ** \since 2.1
+ **
+ ** \deprecated As of 2.2.  Please use
+ ** KIM_SimulatorModel_GetParameterFileBasename() instead.
  **/
 int KIM_SimulatorModel_GetParameterFileName(
     KIM_SimulatorModel const * const simulatorModel,
     int const index,
     char const ** const parameterFileName);
+
+/**
+ ** \brief \copybrief KIM::SimulatorModel::GetParameterFileBasename
+ **
+ ** \sa KIM::SimulatorModel::GetParameterFileBasename,
+ ** kim_simulator_model_module::kim_get_parameter_file_basename
+ **
+ ** \since 2.2
+ **/
+int KIM_SimulatorModel_GetParameterFileBasename(
+    KIM_SimulatorModel const * const simulatorModel,
+    int const index,
+    char const ** const parameterFileBasename);
 
 /**
  ** \brief \copybrief KIM::SimulatorModel::SetSimulatorBufferPointer

--- a/c/src/KIM_ModelDriverCreate_c.cpp
+++ b/c/src/KIM_ModelDriverCreate_c.cpp
@@ -163,6 +163,17 @@ KIM::SpeciesName makeSpeciesNameCpp(KIM_SpeciesName const speciesName)
 }  // namespace
 
 extern "C" {
+void KIM_ModelDriverCreate_GetParameterFileDirectoryName(
+    KIM_ModelDriverCreate const * const modelDriverCreate,
+    char const ** const directoryName)
+{
+  CONVERT_POINTER;
+
+  std::string const * pStr = NULL;
+  pModelDriverCreate->GetParameterFileDirectoryName(&pStr);
+  *directoryName = pStr->c_str();
+}
+
 void KIM_ModelDriverCreate_GetNumberOfParameterFiles(
     KIM_ModelDriverCreate const * const modelDriverCreate,
     int * const numberOfParameterFiles)
@@ -193,6 +204,31 @@ int KIM_ModelDriverCreate_GetParameterFileName(
   else
   {
     if (parameterFileName != NULL) *parameterFileName = pStr->c_str();
+    return false;
+  }
+}
+
+int KIM_ModelDriverCreate_GetParameterFileBasename(
+    KIM_ModelDriverCreate const * const modelDriverCreate,
+    int const index,
+    char const ** const parameterFileBasename)
+{
+  CONVERT_POINTER;
+
+  std::string const * pStr;
+  std::string const ** ppStr;
+  if (parameterFileBasename == NULL)
+    ppStr = NULL;
+  else
+    ppStr = &pStr;
+
+  int error = pModelDriverCreate->GetParameterFileBasename(index, ppStr);
+
+  if (error)
+    return true;
+  else
+  {
+    if (parameterFileBasename != NULL) *parameterFileBasename = pStr->c_str();
     return false;
   }
 }

--- a/c/src/KIM_SimulatorModel_c.cpp
+++ b/c/src/KIM_SimulatorModel_c.cpp
@@ -299,6 +299,25 @@ int KIM_SimulatorModel_GetParameterFileName(
   }
 }
 
+int KIM_SimulatorModel_GetParameterFileBasename(
+    KIM_SimulatorModel const * const simulatorModel,
+    int const index,
+    char const ** const parameterFileBasename)
+{
+  CONVERT_POINTER;
+
+  std::string const * pStrParameterFileBasename;
+  int error = pSimulatorModel->GetParameterFileBasename(
+      index, &pStrParameterFileBasename);
+  if (error)
+    return true;
+  else
+  {
+    *parameterFileBasename = pStrParameterFileBasename->c_str();
+    return false;
+  }
+}
+
 void KIM_SimulatorModel_SetSimulatorBufferPointer(
     KIM_SimulatorModel * const simulatorModel, void * const ptr)
 {

--- a/cpp/include/KIM_ModelDriverCreate.hpp
+++ b/cpp/include/KIM_ModelDriverCreate.hpp
@@ -67,6 +67,19 @@ class ModelDriverCreateImplementation;
 class ModelDriverCreate
 {
  public:
+  /// \brief Get absolute path name of the temporary directory where parameter
+  /// files provided by the model are written.
+  ///
+  /// \param[out] directoryName The absolute path name of the Model's
+  ///             temporary parameter file directory.
+  ///
+  /// \sa KIM_ModelDriverCreate_GetParameterFileDirectoryName,
+  /// kim_model_driver_create_module::kim_get_parameter_file_directory_name
+  ///
+  /// \since 2.2
+  void
+  GetParameterFileDirectoryName(std::string const ** const directoryName) const;
+
   /// \brief Get the number of parameter files provided by the parameterized
   /// model.
   ///
@@ -93,8 +106,30 @@ class ModelDriverCreate
   /// kim_model_driver_create_module::kim_get_parameter_file_name
   ///
   /// \since 2.0
+  ///
+  /// \deprecated As of 2.2.  Please use GetParameterFileDirectoryName() and
+  /// GetParameterFileBasename() instead.
   int GetParameterFileName(int const index,
                            std::string const ** const parameterFileName) const;
+
+  /// \brief Get a particular parameter file basename.  The file is located in
+  /// the Model's parameter file directory.
+  ///
+  /// \param[in] index Zero-based index for the parameter file of interest.
+  /// \param[out] parameterFileBasename The basename (file name without path)
+  ///             for the parameter file of interest.
+  ///
+  /// \return \c true if the Model object is not a parameterized model
+  /// \return \c true if \c index is invalid.
+  /// \return \c true if `parameterFileBasename == NULL`.
+  /// \return \c false otherwise.
+  ///
+  /// \sa KIM_ModelDriverCreate_GetParameterFileBasename,
+  /// kim_model_driver_create_module::kim_get_parameter_file_basename
+  ///
+  /// \since 2.2
+  int GetParameterFileBasename(
+      int const index, std::string const ** const parameterFileBasename) const;
 
   /// \brief Set the Model's particle Numbering.
   ///

--- a/cpp/include/KIM_SimulatorModel.hpp
+++ b/cpp/include/KIM_SimulatorModel.hpp
@@ -418,8 +418,30 @@ class SimulatorModel
   /// kim_simulator_model_module::kim_get_parameter_file_name
   ///
   /// \since 2.1
+  ///
+  /// \deprecated As of 2.2.  Please use GetParameterFileBasename() instead.
   int GetParameterFileName(int const index,
                            std::string const ** const parameterFileName) const;
+
+  /// \brief Get the basename (file name without path) of a particular
+  /// parameter file.  The file is located in the SimulatorModel's parameter
+  /// file directory.
+  ///
+  /// \param[in]  index Zero-based index for the parameter file of interest.
+  /// \param[out] parameterFileBasename Basename (file name without path) of
+  ///             the parameter file.
+  ///
+  /// \post \c parameterFileBasename is unchanged if an error occurs.
+  ///
+  /// \return \c true if \c index is invalid.
+  /// \return \c false otherwise.
+  ///
+  /// \sa KIM_SimulatorModel_GetParameterFileBasename,
+  /// kim_simulator_model_module::kim_get_parameter_file_basename
+  ///
+  /// \since 2.2
+  int GetParameterFileBasename(
+      int const index, std::string const ** const parameterFileBasename) const;
 
   /// \brief Set the \ref cache_buffer_pointers "Simulator's buffer pointer"
   /// within the SimulatorModel object.

--- a/cpp/src/KIM_ModelDriverCreate.cpp
+++ b/cpp/src/KIM_ModelDriverCreate.cpp
@@ -71,6 +71,14 @@
 
 namespace KIM
 {
+void ModelDriverCreate::GetParameterFileDirectoryName(
+    std::string const ** const directoryName) const
+{
+  CONVERT_POINTER;
+
+  pImpl->GetParameterFileDirectoryName(directoryName);
+}
+
 void ModelDriverCreate::GetNumberOfParameterFiles(
     int * const numberOfParameterFiles) const
 {
@@ -85,6 +93,13 @@ int ModelDriverCreate::GetParameterFileName(
   CONVERT_POINTER;
 
   return pImpl->GetParameterFileName(index, parameterFileName);
+}
+int ModelDriverCreate::GetParameterFileBasename(
+    int const index, std::string const ** const parameterFileBasename) const
+{
+  CONVERT_POINTER;
+
+  return pImpl->GetParameterFileBasename(index, parameterFileBasename);
 }
 
 

--- a/cpp/src/KIM_ModelImplementation.cpp
+++ b/cpp/src/KIM_ModelImplementation.cpp
@@ -3046,11 +3046,12 @@ int ModelImplementation::InitializeParameterizedModel(
 #endif
   LOG_DEBUG("Enter  " + callString);
 
+  int error;
 #if ERROR_VERBOSITY
-  int error = (!requestedLengthUnit.Known()) || (!requestedEnergyUnit.Known())
-              || (!requestedChargeUnit.Known())
-              || (!requestedTemperatureUnit.Known())
-              || (!requestedTimeUnit.Known());
+  error = (!requestedLengthUnit.Known()) || (!requestedEnergyUnit.Known())
+          || (!requestedChargeUnit.Known())
+          || (!requestedTemperatureUnit.Known())
+          || (!requestedTimeUnit.Known());
   if (error)
   {
     LOG_ERROR("Invalid arguments.");

--- a/cpp/src/KIM_ModelImplementation.hpp
+++ b/cpp/src/KIM_ModelImplementation.hpp
@@ -289,8 +289,6 @@ class ModelImplementation
       TemperatureUnit const requestedTemperatureUnit,
       TimeUnit const requestedTimeUnit);
 
-  int WriteParameterFiles();
-
   bool numberingHasBeenSet_;
   Numbering modelNumbering_;
   Numbering simulatorNumbering_;

--- a/cpp/src/KIM_ModelImplementation.hpp
+++ b/cpp/src/KIM_ModelImplementation.hpp
@@ -150,9 +150,13 @@ class ModelImplementation
                 TimeUnit * const timeUnit) const;
 
 
+  void
+  GetParameterFileDirectoryName(std::string const ** const directoryName) const;
   int GetNumberOfParameterFiles(int * const numberOfParameterFiles) const;
   int GetParameterFileName(int const index,
                            std::string const ** const parameterFileName) const;
+  int GetParameterFileBasename(
+      int const index, std::string const ** const parameterFileBasename) const;
 
   void SetParameterFileName(std::string const & filename) const;
 
@@ -271,8 +275,10 @@ class ModelImplementation
   std::string modelDriverName_;
 
   SharedLibrary * sharedLibrary_;
+  std::string parameterFileDirectoryName_;
   int numberOfParameterFiles_;
   std::vector<std::string> parameterFileNames_;
+  std::vector<std::string> parameterFileBasenames_;
 
   Log * log_;
 

--- a/cpp/src/KIM_SharedLibrary.cpp
+++ b/cpp/src/KIM_SharedLibrary.cpp
@@ -30,9 +30,13 @@
 // Release: This file is part of the kim-api.git repository.
 //
 
+#include <cstdio>
+#include <cstdlib>
 #include <cstring>
+#include <dirent.h>
 #include <dlfcn.h>
 #include <sstream>
+#include <unistd.h>  // IWYU pragma: keep
 
 #ifndef KIM_SHARED_LIBRARY_HPP_
 #include "KIM_SharedLibrary.hpp"
@@ -80,6 +84,7 @@ SharedLibrary::SharedLibrary(Log * const log) :
     createRoutine_(NULL),
     numberOfParameterFiles_(0),
     numberOfMetadataFiles_(0),
+    parameterFileDirectoryName_(""),
     log_(log)
 {
 #if DEBUG_VERBOSITY
@@ -275,6 +280,8 @@ int SharedLibrary::Close()
     LOG_DEBUG("Exit 1=" + callString);
     return true;  // not open
   }
+
+  RemoveParameterFileDirectory();
 
   sharedLibraryName_ = "";
   sharedLibrarySchemaVersion_ = 0;
@@ -524,6 +531,177 @@ int SharedLibrary::GetSimulatorModelSpecificationFile(
     *specFileLength = (simulatorModelSpecificationFile_).fileLength;
   if (specFileData != NULL)
     *specFileData = (simulatorModelSpecificationFile_).filePointer;
+
+  LOG_DEBUG("Exit 0=" + callString);
+  return false;
+}
+
+int SharedLibrary::WriteParameterFileDirectory()
+{
+#if DEBUG_VERBOSITY
+  std::string const callString = "WriteParameterFileDirectory().";
+#endif
+  LOG_DEBUG("Enter  " + callString);
+
+  int error;
+
+  if (sharedLibraryHandle_ == NULL)
+  {
+    LOG_ERROR("Library not open.");
+    LOG_DEBUG("Exit 1=" + callString);
+    return true;  // not open
+  }
+
+  static char const parameterFileDirectoryNameString[]
+      = "kim-shared-library-parameter-file-directory-XXXXXXXXXXXX";
+  std::stringstream templateString;
+  templateString << P_tmpdir
+                 << ((*(--(std::string(P_tmpdir).end())) == '/') ? "" : "/")
+                 << parameterFileDirectoryNameString;
+  char * cstr = strdup(templateString.str().c_str());
+  char * tmpdir = mkdtemp(cstr);
+  if (NULL == tmpdir)
+  {
+    free(cstr);
+    LOG_ERROR("Could not create a secure temporary directory.");
+    LOG_DEBUG("Exit 1=" + callString);
+    return true;
+  }
+  parameterFileDirectoryName_ = tmpdir;
+  free(cstr);
+
+  if (itemType_ == KIM::COLLECTION_ITEM_TYPE::simulatorModel)
+  {
+    unsigned int len;
+    unsigned char const * specificationData;
+    std::string specFileName;
+    error = GetSimulatorModelSpecificationFile(
+        &specFileName, &len, &specificationData);
+    if (error)
+    {
+      LOG_ERROR("Unable to get specification file.");
+      RemoveParameterFileDirectory();
+      LOG_DEBUG("Exit 1=" + callString);
+      return true;
+    }
+    std::string const specificationFilePathName
+        = parameterFileDirectoryName_ + "/" + specFileName;
+    FILE * fl = fopen(specificationFilePathName.c_str(), "w");
+    if (NULL == fl)
+    {
+      LOG_ERROR("Unable to get write parameter file.");
+      RemoveParameterFileDirectory();
+      LOG_DEBUG("Exit 1=" + callString);
+      return true;
+    }
+    fwrite(specificationData, sizeof(unsigned char), len, fl);
+    fclose(fl);
+    fl = NULL;
+  }
+
+  int noParamFiles;
+  GetNumberOfParameterFiles(&noParamFiles);
+  std::vector<unsigned char const *> parameterFileStrings;
+  std::vector<unsigned int> parameterFileStringLengths;
+  for (int i = 0; i < noParamFiles; ++i)
+  {
+    std::string parameterFileName;
+    unsigned char const * strPtr;
+    unsigned int length;
+    error = GetParameterFile(i, &parameterFileName, &length, &strPtr);
+    if (error)
+    {
+      LOG_ERROR("Could not get parameter file data.");
+      LOG_DEBUG("Exit 1=" + callString);
+      return true;
+    }
+
+    std::string const parameterFilePathName
+        = parameterFileDirectoryName_ + "/" + parameterFileName;
+    FILE * fl = fopen(parameterFilePathName.c_str(), "w");
+    if (NULL == fl)
+    {
+      LOG_ERROR("Unable to get write parameter file.");
+      RemoveParameterFileDirectory();
+      LOG_DEBUG("Exit 1=" + callString);
+      return true;
+    }
+    fwrite(strPtr, sizeof(unsigned char), length, fl);
+    fclose(fl);
+    fl = NULL;
+  }
+
+  LOG_DEBUG("Exit 0=" + callString);
+  return false;
+}
+
+int SharedLibrary::GetParameterFileDirectoryName(
+    std::string * const directoryName) const
+{
+#if DEBUG_VERBOSITY
+  std::string const callString
+      = "GetParameterFileDirectoryName(" + SPTR(directoryName) + ").";
+#endif
+  LOG_DEBUG("Enter  " + callString);
+
+  if (sharedLibraryHandle_ == NULL)
+  {
+    LOG_ERROR("Library not open.");
+    LOG_DEBUG("Exit 1=" + callString);
+    return true;  // not open
+  }
+
+  *directoryName = parameterFileDirectoryName_;
+
+  LOG_DEBUG("Exit 0=" + callString);
+  return false;
+}
+
+int SharedLibrary::RemoveParameterFileDirectory()
+{
+#if DEBUG_VERBOSITY
+  std::string const callString = "RemoveParameterFileDirectory().";
+#endif
+  LOG_DEBUG("Enter  " + callString);
+
+  if (sharedLibraryHandle_ == NULL)
+  {
+    LOG_ERROR("Library not open.");
+    LOG_DEBUG("Exit 1=" + callString);
+    return true;  // not open
+  }
+
+  if (parameterFileDirectoryName_ != "")
+  {
+    int error;
+    struct dirent * dp = NULL;
+    DIR * dir = NULL;
+    dir = opendir(parameterFileDirectoryName_.c_str());
+    while ((dp = readdir(dir)))
+    {
+      // assuming no subdirectories, just files
+      if ((0 != strcmp(dp->d_name, ".")) && (0 != strcmp(dp->d_name, "..")))
+      {
+        std::string filePath = parameterFileDirectoryName_ + "/" + dp->d_name;
+        error = remove(filePath.c_str());
+        if (error)
+        {
+          LOG_ERROR("Unable to remove simulator model file '" + filePath
+                    + "'.");
+        }
+      }
+    }
+    closedir(dir);
+    error = remove(parameterFileDirectoryName_.c_str());
+    if (error)
+    {
+      LOG_ERROR("Unable to remove simulator model parameter file directory '"
+                + parameterFileDirectoryName_ + "'.");
+    }
+
+    // clear out directory name variable
+    parameterFileDirectoryName_ = "";
+  }
 
   LOG_DEBUG("Exit 0=" + callString);
   return false;

--- a/cpp/src/KIM_SharedLibrary.hpp
+++ b/cpp/src/KIM_SharedLibrary.hpp
@@ -80,6 +80,11 @@ class SharedLibrary
       std::string * const specFileName,
       unsigned int * const specFileLength,
       unsigned char const ** const specFileData) const;
+
+  int WriteParameterFileDirectory();
+  int GetParameterFileDirectoryName(std::string * const directoryName) const;
+  int RemoveParameterFileDirectory();
+
   int GetDriverName(std::string * const driverName) const;
   int GetNumberOfMetadataFiles(int * const numberOfMetadataFiles) const;
   int GetMetadataFile(int const index,
@@ -116,6 +121,8 @@ class SharedLibrary
   std::vector<EmbeddedFile> parameterFiles_;
   int numberOfMetadataFiles_;
   std::vector<EmbeddedFile> metadataFiles_;
+
+  std::string parameterFileDirectoryName_;
 
   Log * log_;
 };  // class SharedLibrary

--- a/cpp/src/KIM_SimulatorModel.cpp
+++ b/cpp/src/KIM_SimulatorModel.cpp
@@ -157,6 +157,12 @@ int SimulatorModel::GetParameterFileName(
   return pimpl->GetParameterFileName(index, parameterFileName);
 }
 
+int SimulatorModel::GetParameterFileBasename(
+    int const index, std::string const ** const parameterFileBasename) const
+{
+  return pimpl->GetParameterFileBasename(index, parameterFileBasename);
+}
+
 void SimulatorModel::SetSimulatorBufferPointer(void * const ptr)
 {
   pimpl->SetSimulatorBufferPointer(ptr);

--- a/cpp/src/KIM_SimulatorModelImplementation.cpp
+++ b/cpp/src/KIM_SimulatorModelImplementation.cpp
@@ -313,13 +313,14 @@ void SimulatorModelImplementation::AddStandardTemplatesToMap()
 
   AddTemplateMap("parameter-file-dir", parameterFileDirectoryName_);
 
-  for (size_t i = 0; i < parameterFileNames_.size(); ++i)
+  for (size_t i = 0; i < parameterFileBasenames_.size(); ++i)
   {
     AddTemplateMap("parameter-file-basename-" + SNUM(i + 1),
-                   parameterFileNames_[i]);
+                   parameterFileBasenames_[i]);
 
     AddTemplateMap("parameter-file-" + SNUM(i + 1),
-                   parameterFileDirectoryName_ + "/" + parameterFileNames_[i]);
+                   parameterFileDirectoryName_ + "/"
+                       + parameterFileBasenames_[i]);
   }
 
   LOG_DEBUG("Exit 0=" + callString);
@@ -504,6 +505,9 @@ int SimulatorModelImplementation::GetParameterFileName(
                                  + SPTR(parameterFileName) + ").";
 #endif
   LOG_DEBUG("Enter  " + callString);
+  LOG_WARNING("Use of the " + callString
+              + " function is deprecated. "
+                "Please use GetParameterFileBasename() instead.");
 
 #if ERROR_VERBOSITY
   if ((index < 0) || (index >= numberOfParameterFiles_))
@@ -514,7 +518,31 @@ int SimulatorModelImplementation::GetParameterFileName(
   }
 #endif
 
-  *parameterFileName = &parameterFileNames_[index];
+  *parameterFileName = &parameterFileBasenames_[index];
+
+  LOG_DEBUG("Exit 0=" + callString);
+  return false;
+}
+
+int SimulatorModelImplementation::GetParameterFileBasename(
+    int const index, std::string const ** const parameterFileBasename) const
+{
+#if DEBUG_VERBOSITY
+  std::string const callString = "GetParameterFileBasename(" + SNUM(index)
+                                 + ", " + SPTR(parameterFileBasename) + ").";
+#endif
+  LOG_DEBUG("Enter  " + callString);
+
+#if ERROR_VERBOSITY
+  if ((index < 0) || (index >= numberOfParameterFiles_))
+  {
+    LOG_ERROR("Invalid parameter file index, " + SNUM(index) + ".");
+    LOG_DEBUG("Exit 1=" + callString);
+    return true;
+  }
+#endif
+
+  *parameterFileBasename = &parameterFileBasenames_[index];
 
   LOG_DEBUG("Exit 0=" + callString);
   return false;
@@ -642,7 +670,7 @@ std::string const & SimulatorModelImplementation::ToString() const
     ss << "\t"
        << "index : " << i << "\n"
        << "\t  "
-       << "name : " << parameterFileNames_[i] << "\n\n";
+       << "name : " << parameterFileBasenames_[i] << "\n\n";
   }
 
   ss << "Original simulator fields :\n";
@@ -806,11 +834,11 @@ int SimulatorModelImplementation::Initialize(
         || sharedLibrary_->GetNumberOfParameterFiles(&numberOfParameterFiles_);
   for (int i = 0; i < numberOfParameterFiles_; ++i)
   {
-    std::string parameterFileName;
+    std::string parameterFileBasename;
     error = error
             || sharedLibrary_->GetParameterFile(
-                i, &parameterFileName, NULL, NULL);
-    if (!error) { parameterFileNames_.push_back(parameterFileName); }
+                i, &parameterFileBasename, NULL, NULL);
+    if (!error) { parameterFileBasenames_.push_back(parameterFileBasename); }
   }
   if (error)
   {

--- a/cpp/src/KIM_SimulatorModelImplementation.hpp
+++ b/cpp/src/KIM_SimulatorModelImplementation.hpp
@@ -100,6 +100,8 @@ class SimulatorModelImplementation
 
   int GetParameterFileName(int const index,
                            std::string const ** const parameterFileName) const;
+  int GetParameterFileBasename(
+      int const index, std::string const ** const parameterFileBasename) const;
 
   void SetSimulatorBufferPointer(void * const ptr);
 
@@ -158,7 +160,7 @@ class SimulatorModelImplementation
   std::vector<std::vector<std::string> > simulatorFields_;
 
   int numberOfParameterFiles_;
-  std::vector<std::string> parameterFileNames_;
+  std::vector<std::string> parameterFileBasenames_;
 
   bool templateMapOpen_;
   std::map<std::string, std::string> templateMap_;

--- a/cpp/src/KIM_SimulatorModelImplementation.hpp
+++ b/cpp/src/KIM_SimulatorModelImplementation.hpp
@@ -143,8 +143,6 @@ class SimulatorModelImplementation
   int GetSchemaVersion();
   int ReadEdnSchemaV1();
   int Initialize(std::string const & simulatorModelName);
-  int WriteParameterFileDirectory();
-  void RemoveParameterFileDirectory();
 
   std::string parameterFileDirectoryName_;
   std::string specificationFileName_;

--- a/examples/model-drivers/LennardJones612__MD_414112407348_003/LennardJones612Implementation.cpp
+++ b/examples/model-drivers/LennardJones612__MD_414112407348_003/LennardJones612Implementation.cpp
@@ -299,16 +299,19 @@ int LennardJones612Implementation::OpenParameterFiles(
     return ier;
   }
 
+  std::string const * paramFileDirName;
+  modelDriverCreate->GetParameterFileDirectoryName(&paramFileDirName);
   for (int i = 0; i < numberParameterFiles; ++i)
   {
     std::string const * paramFileName;
-    ier = modelDriverCreate->GetParameterFileName(i, &paramFileName);
+    ier = modelDriverCreate->GetParameterFileBasename(i, &paramFileName);
     if (ier)
     {
       LOG_ERROR("Unable to get parameter file name");
       return ier;
     }
-    parameterFilePointers[i] = fopen(paramFileName->c_str(), "r");
+    std::string filename = *paramFileDirName + "/" + *paramFileName;
+    parameterFilePointers[i] = fopen(filename.c_str(), "r");
     if (parameterFilePointers[i] == 0)
     {
       char message[MAXLINE];

--- a/examples/model-drivers/ex_model_driver_P_LJ/ex_model_driver_P_LJ.f90
+++ b/examples/model-drivers/ex_model_driver_P_LJ/ex_model_driver_P_LJ.f90
@@ -707,6 +707,8 @@ integer(c_int), intent(out) :: ierr
 !-- Local variables
 integer i
 integer(c_int) :: number_of_parameter_files
+character(len=1024, kind=c_char) :: parameter_file_directory_name
+character(len=1024, kind=c_char) :: parameter_file_basename
 character(len=1024, kind=c_char) :: parameter_file_name
 integer(c_int) :: ierr2
 type(BUFFER_TYPE), pointer :: buf;
@@ -791,14 +793,18 @@ end if
 
 ! Read in model parameters from parameter file
 !
-call kim_get_parameter_file_name( &
-  model_driver_create_handle, 1, parameter_file_name, ierr)
+call kim_get_parameter_file_directory_name( &
+  model_driver_create_handle, parameter_file_directory_name)
+call kim_get_parameter_file_basename( &
+  model_driver_create_handle, 1, parameter_file_basename, ierr)
 if (ierr /= 0) then
   call kim_log_entry(model_driver_create_handle, &
-    KIM_LOG_VERBOSITY_ERROR, "Unable to get parameter file name")
+    KIM_LOG_VERBOSITY_ERROR, "Unable to get parameter file basename")
   ierr = 1
   goto 42
 end if
+parameter_file_name = trim(parameter_file_directory_name) //"/"// &
+  trim(parameter_file_basename)
 open(10,file=parameter_file_name,status="old")
 read(10,*,iostat=ierr,err=100) in_species
 read(10,*,iostat=ierr,err=100) in_cutoff

--- a/examples/model-drivers/ex_model_driver_P_Morse/ex_model_driver_P_Morse.c
+++ b/examples/model-drivers/ex_model_driver_P_Morse/ex_model_driver_P_Morse.c
@@ -391,7 +391,9 @@ int model_driver_create(KIM_ModelDriverCreate * const modelDriverCreate,
 {
   /* KIM variables */
   int numberOfParameterFiles;
-  char const * paramfile1name;
+  char const * paramfiledirname;
+  char const * paramfilebasename;
+  char paramfile1name[2048];
 
   /* Local variables */
   FILE * fid;
@@ -494,13 +496,16 @@ int model_driver_create(KIM_ModelDriverCreate * const modelDriverCreate,
     LOG_ERROR("Incorrect number of parameter files.");
     return ier;
   }
-  ier = KIM_ModelDriverCreate_GetParameterFileName(
-      modelDriverCreate, 0, &paramfile1name);
+  KIM_ModelDriverCreate_GetParameterFileDirectoryName(modelDriverCreate,
+                                                      &paramfiledirname);
+  ier = KIM_ModelDriverCreate_GetParameterFileBasename(
+      modelDriverCreate, 0, &paramfilebasename);
   if (ier == TRUE)
   {
-    LOG_ERROR("Unable to get parameter file name.");
+    LOG_ERROR("Unable to get parameter file basename.");
     return ier;
   }
+  sprintf(paramfile1name, "%s/%s", paramfiledirname, paramfilebasename);
 
   /* Read in model parameters from parameter file */
   fid = fopen(paramfile1name, "r");

--- a/examples/simulators/simulator-model-example/simulator-model-example-c.cpp
+++ b/examples/simulators/simulator-model-example/simulator-model-example-c.cpp
@@ -136,19 +136,21 @@ int main()
               << " parameter files:" << std::endl;
     for (int i = 0; i < numberParamFiles; ++i)
     {
-      char const * pParamFileName;
-      error = KIM_SimulatorModel_GetParameterFileName(SM, i, &pParamFileName);
+      char const * pParamFileBasename;
+      error = KIM_SimulatorModel_GetParameterFileBasename(
+          SM, i, &pParamFileBasename);
       if (error)
       {
-        std::cout << "Unable to get parameter file name." << std::endl;
+        std::cout << "Unable to get parameter file basename." << std::endl;
         goto fail;
       }
       else
       {
         std::cout << "Parameter file " << std::setw(2) << i
-                  << " has name : " << pParamFileName << std::endl;
-        error = system(
-            (std::string("cat ") + pDirName + "/" + pParamFileName).c_str());
+                  << " has basename : " << pParamFileBasename << std::endl;
+        error
+            = system((std::string("cat ") + pDirName + "/" + pParamFileBasename)
+                         .c_str());
         std::cout << std::endl;
       }
     }

--- a/examples/simulators/simulator-model-example/simulator-model-example-fortran.f90
+++ b/examples/simulators/simulator-model-example/simulator-model-example-fortran.f90
@@ -80,7 +80,7 @@ program collections_example_fortran
   character(len=2048, kind=c_char) line
   character(len=2048, kind=c_char) dir_name
   character(len=2048, kind=c_char) spec_name
-  character(len=2048, kind=c_char) param_name
+  character(len=2048, kind=c_char) param_basename
 
 
   call kim_simulator_model_create( &
@@ -140,13 +140,13 @@ program collections_example_fortran
   call kim_get_number_of_parameter_files(sm, extent)
   print '("SM has ",I1," parameter files:")', extent
   do i=1,extent
-    call kim_get_parameter_file_name(sm, i, param_name, ierr)
+    call kim_get_parameter_file_basename(sm, i, param_basename, ierr)
     if (ierr /= 0) then
-      call my_error("Unable to get parameter file name.")
+      call my_error("Unable to get parameter file basename.")
     else
-      print '("Parameter file ",I2," has name ",A)', i, trim(param_name)
+      print '("Parameter file ",I2," has basename ",A)', i, trim(param_basename)
       ierr = c_system( &
-        "cat "//trim(dir_name)//"/"//trim(param_name)//c_null_char)
+        "cat "//trim(dir_name)//"/"//trim(param_basename)//c_null_char)
       print *,""
     end if
   end do

--- a/examples/simulators/simulator-model-example/simulator-model-example.cpp
+++ b/examples/simulators/simulator-model-example/simulator-model-example.cpp
@@ -133,19 +133,20 @@ int main()
               << " parameter files:" << std::endl;
     for (int i = 0; i < numberParamFiles; ++i)
     {
-      std::string const * pParamFileName;
-      error = SM->GetParameterFileName(i, &pParamFileName);
+      std::string const * pParamFileBasename;
+      error = SM->GetParameterFileBasename(i, &pParamFileBasename);
       if (error)
       {
-        std::cout << "Unable to get parameter file name." << std::endl;
+        std::cout << "Unable to get parameter file basename." << std::endl;
         goto fail;
       }
       else
       {
         std::cout << "Parameter file " << std::setw(2) << i
-                  << " has name : " << *pParamFileName << std::endl;
+                  << " has basename : " << *pParamFileBasename << std::endl;
         error = system(
-            (std::string("cat ") + *pDirName + "/" + *pParamFileName).c_str());
+            (std::string("cat ") + *pDirName + "/" + *pParamFileBasename)
+                .c_str());
         std::cout << std::endl;
       }
     }

--- a/fortran/include/kim_model_driver_create_module.f90
+++ b/fortran/include/kim_model_driver_create_module.f90
@@ -51,8 +51,10 @@ module kim_model_driver_create_module
     ! Routines
     operator (.eq.), &
     operator (.ne.), &
+    kim_get_parameter_file_directory_name, &
     kim_get_number_of_parameter_files, &
     kim_get_parameter_file_name, &
+    kim_get_parameter_file_basename, &
     kim_set_model_numbering, &
     kim_set_influence_distance_pointer, &
     kim_set_neighbor_list_pointers, &
@@ -95,6 +97,16 @@ module kim_model_driver_create_module
     module procedure kim_model_driver_create_handle_not_equal
   end interface operator (.ne.)
 
+  !> \brief \copybrief KIM::ModelDriverCreate::GetParameterFileDirectoryName
+  !!
+  !! \sa KIM::ModelDriverCreate::GetParameterFileDirectoryName,
+  !! KIM_ModelDriverCreate_GetParameterFileDirectoryName
+  !!
+  !! \since 2.2
+  interface kim_get_parameter_file_directory_name
+    module procedure kim_model_driver_create_get_parameter_file_directory_name
+  end interface kim_get_parameter_file_directory_name
+
   !> \brief \copybrief KIM::ModelDriverCreate::GetNumberOfParameterFiles
   !!
   !! \sa KIM::ModelDriverCreate::GetNumberOfParameterFiles,
@@ -111,9 +123,22 @@ module kim_model_driver_create_module
   !! KIM_ModelDriverCreate_GetParameterFileName
   !!
   !! \since 2.0
+  !!
+  !! \deprecated As of 2.2.  Please use
+  !! kim_model_driver_create_module::kim_get_parameter_file_basename() instead.
   interface kim_get_parameter_file_name
     module procedure kim_model_driver_create_get_parameter_file_name
   end interface kim_get_parameter_file_name
+
+  !> \brief \copybrief KIM::ModelDriverCreate::GetParameterFileBasename
+  !!
+  !! \sa KIM::ModelDriverCreate::GetParameterFileBasename,
+  !! KIM_ModelDriverCreate_GetParameterFileBasename
+  !!
+  !! \since 2.2
+  interface kim_get_parameter_file_basename
+    module procedure kim_model_driver_create_get_parameter_file_basename
+  end interface kim_get_parameter_file_basename
 
   !> \brief \copybrief KIM::ModelDriverCreate::SetModelNumbering
   !!
@@ -250,6 +275,41 @@ contains
     kim_model_driver_create_handle_not_equal = .not. (lhs .eq. rhs)
   end function kim_model_driver_create_handle_not_equal
 
+  !> \brief \copybrief KIM::ModelDriverCreate::GetParameterFileDirectoryName
+  !!
+  !! \sa KIM::ModelDriverCreate::GetParameterFileDirectoryName,
+  !! KIM_ModelDriverCreate_GetParameterFileDirectoryName
+  !!
+  !! \since 2.2
+  recursive subroutine &
+    kim_model_driver_create_get_parameter_file_directory_name( &
+    model_driver_create_handle, directory_name)
+    use kim_interoperable_types_module, only : kim_model_driver_create_type
+    use kim_convert_string_module, only : kim_convert_c_char_ptr_to_string
+    implicit none
+    interface
+      recursive subroutine get_parameter_file_directory_name( &
+        model_driver_create, directory_name) &
+        bind(c, name="KIM_ModelDriverCreate_GetParameterFileDirectoryName")
+        use, intrinsic :: iso_c_binding
+        use kim_interoperable_types_module, only : kim_model_driver_create_type
+        implicit none
+        type(kim_model_driver_create_type), intent(in) :: model_driver_create
+        type(c_ptr), intent(out) :: directory_name
+      end subroutine get_parameter_file_directory_name
+    end interface
+    type(kim_model_driver_create_handle_type), intent(in) :: &
+      model_driver_create_handle
+    character(len=*, kind=c_char), intent(out) :: directory_name
+    type(kim_model_driver_create_type), pointer :: model_driver_create
+
+    type(c_ptr) pdirectory_name
+
+    call c_f_pointer(model_driver_create_handle%p, model_driver_create)
+    call get_parameter_file_directory_name(model_driver_create, pdirectory_name)
+    call kim_convert_c_char_ptr_to_string(pdirectory_name, directory_name)
+  end subroutine kim_model_driver_create_get_parameter_file_directory_name
+
   !> \brief \copybrief KIM::ModelDriverCreate::GetNumberOfParameterFiles
   !!
   !! \sa KIM::ModelDriverCreate::GetNumberOfParameterFiles,
@@ -288,6 +348,9 @@ contains
   !! KIM_ModelDriverCreate_GetParameterFileName
   !!
   !! \since 2.0
+  !!
+  !! \deprecated As of 2.2.  Please use
+  !! kim_model_driver_create_module::kim_get_parameter_file_basename() instead.
   recursive subroutine kim_model_driver_create_get_parameter_file_name( &
     model_driver_create_handle, index, parameter_file_name, ierr)
     use kim_convert_string_module, only : kim_convert_c_char_ptr_to_string
@@ -320,6 +383,45 @@ contains
       index-1, p)
     call kim_convert_c_char_ptr_to_string(p, parameter_file_name)
   end subroutine kim_model_driver_create_get_parameter_file_name
+
+  !> \brief \copybrief KIM::ModelDriverCreate::GetParameterFileBasename
+  !!
+  !! \sa KIM::ModelDriverCreate::GetParameterFileBasename,
+  !! KIM_ModelDriverCreate_GetParameterFileBasename
+  !!
+  !! \since 2.2
+  recursive subroutine kim_model_driver_create_get_parameter_file_basename( &
+    model_driver_create_handle, index, parameter_file_basename, ierr)
+    use kim_convert_string_module, only : kim_convert_c_char_ptr_to_string
+    use kim_interoperable_types_module, only : kim_model_driver_create_type
+    implicit none
+    interface
+      integer(c_int) recursive function get_parameter_file_basename( &
+        model_driver_create, index, parameter_file_basename) &
+        bind(c, name="KIM_ModelDriverCreate_GetParameterFileBasename")
+        use, intrinsic :: iso_c_binding
+        use kim_interoperable_types_module, only : kim_model_driver_create_type
+        implicit none
+        type(kim_model_driver_create_type), intent(in) &
+          :: model_driver_create
+        integer(c_int), intent(in), value :: index
+        type(c_ptr), intent(out) :: parameter_file_basename
+      end function get_parameter_file_basename
+    end interface
+    type(kim_model_driver_create_handle_type), intent(in) &
+      :: model_driver_create_handle
+    integer(c_int), intent(in) :: index
+    character(len=*, kind=c_char), intent(out) :: parameter_file_basename
+    integer(c_int), intent(out) :: ierr
+    type(kim_model_driver_create_type), pointer :: model_driver_create
+
+    type(c_ptr) :: p
+
+    call c_f_pointer(model_driver_create_handle%p, model_driver_create)
+    ierr = get_parameter_file_basename(model_driver_create, &
+      index-1, p)
+    call kim_convert_c_char_ptr_to_string(p, parameter_file_basename)
+  end subroutine kim_model_driver_create_get_parameter_file_basename
 
   !> \brief \copybrief KIM::ModelDriverCreate::SetModelNumbering
   !!

--- a/fortran/include/kim_simulator_model_module.f90
+++ b/fortran/include/kim_simulator_model_module.f90
@@ -67,6 +67,7 @@ module kim_simulator_model_module
     kim_get_specification_file_name, &
     kim_get_number_of_parameter_files, &
     kim_get_parameter_file_name, &
+    kim_get_parameter_file_basename, &
     kim_set_simulator_buffer_pointer, &
     kim_get_simulator_buffer_pointer, &
     kim_to_string, &
@@ -239,9 +240,22 @@ module kim_simulator_model_module
   !! KIM_SimulatorModel_GetParameterFileName
   !!
   !! \since 2.1
+  !!
+  !! \deprecated As of 2.2.  Please use
+  !! kim_simulator_model_module::kim_get_parameter_file_basename() instead.
   interface kim_get_parameter_file_name
     module procedure kim_simulator_model_get_parameter_file_name
   end interface kim_get_parameter_file_name
+
+  !> \brief \copybrief KIM::SimulatorModel::GetParameterFileBasename
+  !!
+  !! \sa KIM::SimulatorModel::GetParameterFileBasename,
+  !! KIM_SimulatorModel_GetParameterFileBasename
+  !!
+  !! \since 2.2
+  interface kim_get_parameter_file_basename
+    module procedure kim_simulator_model_get_parameter_file_basename
+  end interface kim_get_parameter_file_basename
 
   !> \brief \copybrief KIM::SimulatorModel::SetSimulatorBufferPointer
   !!
@@ -803,6 +817,9 @@ contains
   !! KIM_SimulatorModel_GetParameterFileName
   !!
   !! \since 2.1
+  !!
+  !! \deprecated As of 2.2.  Please use
+  !! kim_simulator_model_module::kim_get_parameter_file_basename() instead.
   recursive subroutine kim_simulator_model_get_parameter_file_name( &
     simulator_model_handle, index, parameter_file_name, ierr)
     use kim_interoperable_types_module, only : kim_simulator_model_type
@@ -834,6 +851,44 @@ contains
     call kim_convert_c_char_ptr_to_string(pparameter_file_name, &
       parameter_file_name)
   end subroutine kim_simulator_model_get_parameter_file_name
+
+  !> \brief \copybrief KIM::SimulatorModel::GetParameterFileBasename
+  !!
+  !! \sa KIM::SimulatorModel::GetParameterFileBasename,
+  !! KIM_SimulatorModel_GetParameterFileBasename
+  !!
+  !! \since 2.2
+  recursive subroutine kim_simulator_model_get_parameter_file_basename( &
+    simulator_model_handle, index, parameter_file_basename, ierr)
+    use kim_interoperable_types_module, only : kim_simulator_model_type
+    use kim_convert_string_module, only : kim_convert_c_char_ptr_to_string
+    implicit none
+    interface
+      integer(c_int) recursive function get_parameter_file_basename( &
+        simulator_model, index, parameter_file_basename) &
+        bind(c, name="KIM_SimulatorModel_GetParameterFileBasename")
+        use, intrinsic :: iso_c_binding
+        use kim_interoperable_types_module, only : kim_simulator_model_type
+        implicit none
+        type(kim_simulator_model_type), intent(in) :: simulator_model
+        integer(c_int), intent(in), value :: index
+        type(c_ptr), intent(out) :: parameter_file_basename
+      end function get_parameter_file_basename
+    end interface
+    type(kim_simulator_model_handle_type), intent(in) :: simulator_model_handle
+    integer(c_int), intent(in) :: index
+    character(len=*, kind=c_char), intent(out) :: parameter_file_basename
+    integer(c_int), intent(out) :: ierr
+    type(kim_simulator_model_type), pointer :: simulator_model
+
+    type(c_ptr) pparameter_file_basename
+
+    call c_f_pointer(simulator_model_handle%p, simulator_model)
+    ierr = get_parameter_file_basename(simulator_model, index-1, &
+      pparameter_file_basename)
+    call kim_convert_c_char_ptr_to_string(pparameter_file_basename, &
+      parameter_file_basename)
+  end subroutine kim_simulator_model_get_parameter_file_basename
 
   !> \brief \copybrief KIM::SimulatorModel::SetSimulatorBufferPointer
   !!


### PR DESCRIPTION
This PR unifies the way that parameter files for Simulator Models and Parameterized Models are written to a temporary directory on the file system.

It also adds new routines to the ModelDriverCreate and SimulatorModel APIs to make them fully symmetric.

The PR is backward compatible but deprecates the previous APIs for parameter file handling and encourages users to adopt the new API.