### PR TITLE
Explicitly set the type of the underlying container.

### DIFF
--- a/cpp/src/KIM_LogImplementation.hpp
+++ b/cpp/src/KIM_LogImplementation.hpp
@@ -34,6 +34,7 @@
 #ifndef KIM_LOG_IMPLEMENTATION_HPP_
 #define KIM_LOG_IMPLEMENTATION_HPP_
 
+#include <deque>
 #include <stack>
 #include <string>
 
@@ -93,7 +94,7 @@ class LogImplementation
   std::string GetTimeStamp() const;
 
   std::string idString_;
-  std::stack<LogVerbosity> verbosity_;
+  std::stack<LogVerbosity, std::deque<LogVerbosity> > verbosity_;
 
   LanguageName printFunctionLanguageName_;
   Function * printFunctionPointer_;


### PR DESCRIPTION
This fix prevents a cross-compiling issue on macOS for
CLANG/GCC compilers, where it complains about an invalid
application of 'sizeof' to an incomplete type
'KIM::LogVerbosity' in template class instantiation.