### PR TITLE
Build with ${ORIGIN} on Win32 to make KIM API installation relocatable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -112,18 +112,14 @@ mark_as_advanced(KIM_API_USER_SIMULATOR_MODELS_DIR_DEFAULT)
 macro(_set_system_dir var identifier type_string)
   set(_default_dir_1 "${PROJECT_NAME}/${identifier}")  # _1 single escape -- to be used directly
   set(_default_dir_2 "${PROJECT_NAME}/${identifier}")  # _2 double escape -- to be passed into macro/function
-  set(_description "System collection (${KIM_API_PATH_SEPARATOR}-separated) ${type_string} directory list")
-  if(WIN32)
-    file(TO_CMAKE_PATH "${CMAKE_INSTALL_FULL_LIBDIR}/${_default_dir_1}" _normalized_libdir_1)
-    file(TO_CMAKE_PATH "${CMAKE_INSTALL_FULL_LIBDIR}/${_default_dir_2}" _normalized_libdir_2)
-    set(_default_dir_1 "${_normalized_libdir_1}")
-    set(_default_dir_2 "${_normalized_libdir_2}")
-    unset(_normalized_libdir_1)
-    unset(_normalized_libdir_2)
+  set(_description "System collection (${KIM_API_PATH_SEPARATOR}-separated) ${type_string} directory list (entries may begin with $ORIGIN (w/ or w/o {}'s), if appropriate)")
+  if(WIN32 AND NOT CYGWIN)
+    # Note: On Win32, ${ORIGIN} refers to the bin/ directory containing libkim-api.dll.
+    set(_default_dir_1 "\${ORIGIN}/../lib/${_default_dir_1}")   # Here is the important difference between the _1 and _2
+    set(_default_dir_2 "\\\${ORIGIN}/../lib/${_default_dir_2}") # Here is the important difference between the _1 and _2
   else()
     set(_default_dir_1 "\${ORIGIN}/${_default_dir_1}")   # Here is the important difference between the _1 and _2
     set(_default_dir_2 "\\\${ORIGIN}/${_default_dir_2}") # Here is the important difference between the _1 and _2
-    set(_description "${_description} (entries may begin with $ORIGIN (w/ or w/o {}'s), if appropriate)")
   endif()
   set_cache_with_fallback(${var} "${_default_dir_2}" STRING ${_description})
   if("${${var}}" MATCHES "^${KIM_API_PATH_SEPARATOR}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -115,8 +115,10 @@ macro(_set_system_dir var identifier type_string)
   set(_description "System collection (${KIM_API_PATH_SEPARATOR}-separated) ${type_string} directory list (entries may begin with $ORIGIN (w/ or w/o {}'s), if appropriate)")
   if(WIN32 AND NOT CYGWIN)
     # Note: On Win32, ${ORIGIN} refers to the bin/ directory containing libkim-api.dll.
-    set(_default_dir_1 "\${ORIGIN}/../lib/${_default_dir_1}")   # Here is the important difference between the _1 and _2
-    set(_default_dir_2 "\\\${ORIGIN}/../lib/${_default_dir_2}") # Here is the important difference between the _1 and _2
+    file(RELATIVE_PATH _relative_libdir_path "${CMAKE_INSTALL_FULL_BINDIR}" "${CMAKE_INSTALL_FULL_LIBDIR}")
+    set(_default_dir_1 "\${ORIGIN}/${_relative_libdir_path}/${_default_dir_1}")   # Here is the important difference between the _1 and _2
+    set(_default_dir_2 "\\\${ORIGIN}/${_relative_libdir_path}/${_default_dir_2}") # Here is the important difference between the _1 and _2
+    unset(_relative_libdir_path)
   else()
     set(_default_dir_1 "\${ORIGIN}/${_default_dir_1}")   # Here is the important difference between the _1 and _2
     set(_default_dir_2 "\\\${ORIGIN}/${_default_dir_2}") # Here is the important difference between the _1 and _2
@@ -153,7 +155,9 @@ set_target_properties(kim-api
 target_include_directories(kim-api PUBLIC
   $<BUILD_INTERFACE:$<TARGET_PROPERTY:kim-api,Fortran_MODULE_DIRECTORY>>
   $<INSTALL_INTERFACE:${CMAKE_INSTALL_RELOC_LIBDIR}/${PROJECT_NAME}/${KIM_API_Fortran_MODULE_DIR_IDENTIFIER}>)
-target_link_libraries(kim-api ${CMAKE_DL_LIBS})
+if(NOT WIN32 OR CYGWIN)
+  target_link_libraries(kim-api ${CMAKE_DL_LIBS})
+endif()
 
 # Add install rules for kim-api
 #

--- a/cpp/src/KIM_CollectionsImplementation.cpp
+++ b/cpp/src/KIM_CollectionsImplementation.cpp
@@ -368,7 +368,8 @@ void PrivateReplaceORIGIN(KIM::FILESYSTEM::PathList & pathList,
       {
         // ensure current has no trailing slash
         if (current.filename().empty()) current = current.parent_path();
-        while (!current.parent_path().empty())
+        while (!current.parent_path().empty()
+               && current.parent_path() != current)
         {
           right = current.filename() / right;
           current = current.parent_path();

--- a/cpp/src/KIM_FilesystemPath.hpp
+++ b/cpp/src/KIM_FilesystemPath.hpp
@@ -120,6 +120,10 @@ class Path
   {
     return lhs.path_ == rhs.path_;
   }
+  friend bool operator!=(const Path & lhs, const Path & rhs)
+  {
+    return !(lhs == rhs);
+  }
 
   // Concatenates the current path and the argument.
   Path & concat(const std::string & p);


### PR DESCRIPTION
- Use `${ORIGIN}` substitution variable in default `KIM_SYSTEM_{...}_DIR` paths to make the KIM API installation relocatable also on Win32 platform.
- Avoid infinite loop in `PrivateReplaceORIGIN()` when `${ORIGIN}` is not used.