### PR TITLE
BUG: Fix refresh fcn of ex_model_driver_P_Morse

### DIFF
--- a/examples/model-drivers/ex_model_driver_P_Morse/ex_model_driver_P_Morse.c
+++ b/examples/model-drivers/ex_model_driver_P_Morse/ex_model_driver_P_Morse.c
@@ -642,6 +642,8 @@ int refresh_routine(KIM_ModelRefresh * const modelRefresh)
   /* set shift to -shift */
   buffer->shift = -buffer->shift;
 
+  /* set influence distance to current value of cutoff parameter */
+  buffer->influenceDistance = buffer->cutoff;
 
   /* store model cutoff in KIM object */
   KIM_ModelRefresh_SetInfluenceDistancePointer(modelRefresh,


### PR DESCRIPTION
This example model driver publishes a single scalar "cutoff" parameter.  In its refresh method, updates to this parameter were not reflected in its influence distance parameter.  This isn't a problem in the other two example model drivers.  None of the standalone models appear to publish their parameters, so no problem there either.