### PR TITLE
Add extra check 

### DIFF
--- a/cpp/include/KIM_Collections.hpp
+++ b/cpp/include/KIM_Collections.hpp
@@ -131,10 +131,10 @@ class Collections
   ///
   /// \param[inout] collections Pointer to the Collections object.
   ///
-  /// \pre \c collections points to a previously created %KIM API Collections
+  /// \pre \c *collections points to a previously created %KIM API Collections
   ///      object.
   ///
-  /// \post `collections == NULL`.
+  /// \post `*collections == NULL`.
   ///
   /// \sa KIM_Collections_Destroy,
   /// kim_collections_module::kim_collections_destroy

--- a/cpp/include/KIM_Model.hpp
+++ b/cpp/include/KIM_Model.hpp
@@ -136,9 +136,9 @@ class Model
   ///
   /// \param[inout] model Pointer to the Model object.
   ///
-  /// \pre \c model points to a previously created %KIM API Model object.
+  /// \pre \c *model points to a previously created %KIM API Model object.
   ///
-  /// \post `model == NULL`.
+  /// \post `*model == NULL`.
   ///
   /// \sa KIM_Model_Destroy, kim_model_module::kim_model_destroy
   ///

--- a/cpp/include/KIM_SimulatorModel.hpp
+++ b/cpp/include/KIM_SimulatorModel.hpp
@@ -178,10 +178,10 @@ class SimulatorModel
   ///
   /// \param[inout] simulatorModel Pointer to the SimulatorModel object.
   ///
-  /// \pre \c simulatorModel points to a previously created %KIM API
+  /// \pre \c *simulatorModel points to a previously created %KIM API
   ///      SimulatorModel object.
   ///
-  /// \post `simulatorModel == NULL`.
+  /// \post `*simulatorModel == NULL`.
   ///
   /// \sa KIM_SimulatorModel_Destroy,
   /// kim_simulator_model_module::kim_simulator_model_destroy

--- a/cpp/src/KIM_Collections.cpp
+++ b/cpp/src/KIM_Collections.cpp
@@ -74,7 +74,10 @@ int Collections::Create(Collections ** const collections)
 
 void Collections::Destroy(Collections ** const collections)
 {
-  CollectionsImplementation::Destroy(&((*collections)->pimpl));
+  if (*collections != NULL) 
+  {
+    CollectionsImplementation::Destroy(&((*collections)->pimpl));
+  }
   delete *collections;
   *collections = NULL;
 }

--- a/cpp/src/KIM_Collections.cpp
+++ b/cpp/src/KIM_Collections.cpp
@@ -74,7 +74,7 @@ int Collections::Create(Collections ** const collections)
 
 void Collections::Destroy(Collections ** const collections)
 {
-  if (*collections != NULL) 
+  if (*collections != NULL)
   {
     CollectionsImplementation::Destroy(&((*collections)->pimpl));
   }

--- a/cpp/src/KIM_Log.cpp
+++ b/cpp/src/KIM_Log.cpp
@@ -60,7 +60,10 @@ int Log::Create(Log ** const log)
 
 void Log::Destroy(Log ** const log)
 {
-  LogImplementation::Destroy(&((*log)->pimpl));
+  if (*log != NULL)
+  {
+    LogImplementation::Destroy(&((*log)->pimpl));
+  }
   delete *log;
   *log = NULL;
 }

--- a/cpp/src/KIM_LogImplementation.cpp
+++ b/cpp/src/KIM_LogImplementation.cpp
@@ -114,11 +114,14 @@ int LogImplementation::Create(LogImplementation ** const logImplementation)
 
 void LogImplementation::Destroy(LogImplementation ** const logImplementation)
 {
-  (*logImplementation)
-      ->LogEntry(LOG_VERBOSITY::information,
-                 "Log object destroyed.",
-                 __LINE__,
-                 __FILE__);
+  if (*logImplementation != NULL)
+  {
+    (*logImplementation)
+        ->LogEntry(LOG_VERBOSITY::information,
+                   "Log object destroyed.",
+                   __LINE__,
+                   __FILE__);
+  }
   delete (*logImplementation);
   *logImplementation = NULL;
 }


### PR DESCRIPTION
- Extra check to make sure the object is not already destroyed. The segmentation fault happens when the object is already destroyed and we try to destroy it again by mistake.