### PR TITLE
TST: Restore codecov upload

### DIFF
--- a/.github/workflows/multiplatform-debug-iwyu-sanitize-lto-coverage.yml
+++ b/.github/workflows/multiplatform-debug-iwyu-sanitize-lto-coverage.yml
@@ -46,6 +46,7 @@ jobs:
   macos-debug:
 
     strategy:
+      fail-fast: false
       matrix:
         os: [macos-10.15, macos-11]
         include:
@@ -106,6 +107,7 @@ jobs:
   linux-debug-sanitize:
 
     strategy:
+      fail-fast: false
       matrix:
         os: [fedora, openSUSE, ubuntu, centos, debian]
         include:

--- a/scripts/ci-build-and-test
+++ b/scripts/ci-build-and-test
@@ -138,7 +138,17 @@ if test x"${TEST_BUILD}" = x"yes"; then
   ctest --output-on-failure || exit $?
 
   if test x"${COVERAGE}" != x""; then
-    bash <(curl -s https://codecov.io/bash) || exit $?
+    cd /home/kim/kim-api
+
+    # Run gcov to generate coverage reports
+    bash -c "find /home/kim/kim-api -type f -name '*.gcno' -exec gcov -pb {} +" || exit $?
+
+    # Run codecov uploader
+    curl -Os https://uploader.codecov.io/latest/linux/codecov || exit $?
+    chmod +x codecov || exit $?
+    ./codecov || exit $?
+
+    cd build
   fi
 
   mkdir ${PWD}/destdir

--- a/scripts/ci-build-and-test
+++ b/scripts/ci-build-and-test
@@ -138,15 +138,37 @@ if test x"${TEST_BUILD}" = x"yes"; then
   ctest --output-on-failure || exit $?
 
   if test x"${COVERAGE}" != x""; then
-    cd /home/kim/kim-api
+    # Create directory for housing codecov and its keys
+    CODECOV_DIR=/home/kim/.codecov
+    mkdir ${CODECOV_DIR}
+    cd $CODECOV_DIR
+
+    # Download codecov signing key
+    curl -Os https://keybase.io/codecovsecurity/pgp_keys.asc || exit $?
+
+    # Verify integrity of codecov key by comparing to known hash (codecov has
+    # said this key should never change)
+    sha256sum pgp_keys.asc | xargs -I{} [ "{}" == "d56942c32a1bb70af75bf972302b6114049fb59cb76193fac349bb9b587b60c2  pgp_keys.asc" ] || exit $?
+    gpg --import pgp_keys.asc || exit $?
+
+    # Download signature used to sign the file containing the trusted hash
+    curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM || exit $?
+    curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM.sig || exit $?
+
+    # Verify the file containing the trusted hash
+    gpg --verify codecov.SHA256SUM.sig codecov.SHA256SUM || exit $?
+
+    # Download the codecov uploader and verify its hash
+    curl -Os https://uploader.codecov.io/latest/linux/codecov || exit $?
+    sha256sum -c codecov.SHA256SUM  || exit $?
+    chmod +x ${CODECOV_DIR}/codecov || exit $?
 
     # Run gcov to generate coverage reports
+    cd /home/kim/kim-api
     bash -c "find /home/kim/kim-api -type f -name '*.gcno' -exec gcov -pb {} +" || exit $?
 
     # Run codecov uploader
-    curl -Os https://uploader.codecov.io/latest/linux/codecov || exit $?
-    chmod +x codecov || exit $?
-    ./codecov || exit $?
+    ${CODECOV_DIR}/codecov || exit $?
 
     cd build
   fi

--- a/scripts/ci-docker-build-and-run
+++ b/scripts/ci-docker-build-and-run
@@ -90,8 +90,8 @@ fi
 
 # Store env to pass to docker if COVERAGE requested
 if test x"${COVERAGE}" != x""; then
-  # https://docs.codecov.io/docs/testing-with-docker
-  ci_env=`bash <(curl -s https://codecov.io/env)`
+  # See https://docs.codecov.io/docs/testing-with-docker
+  ci_env="-e CODECOV_ENV -e CODECOV_TOKEN -e CODECOV_URL -e CODECOV_SLUG -e VCS_COMMIT_ID -e VCS_BRANCH_NAME -e VCS_PULL_REQUEST -e VCS_SLUG -e VCS_TAG -e CI_BUILD_URL -e CI_BUILD_ID -e CI_JOB_ID -e GITHUB_ACTIONS -e GITHUB_HEAD_REF -e GITHUB_REF -e GITHUB_REPOSITORY -e GITHUB_RUN_ID -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKFLOW"
 fi
 
 set -xv


### PR DESCRIPTION
Although the coverage reports were being generated before, this PR restores codecov.io functionality and also makes some maintenance updates:

- The codecov bash uploader is now deprecated, so here we switch to the new one

- The new codecov uploader does not run gcov for you (which actually generates the coverage reports), unlike the old bash uploader.  The invocation that was being done in the latter can be found here:

    https://github.com/codecov/codecov-bash/blob/43c5d3c7147b91674dd69c3e0e0becc48eba04bd/codecov#L1219

  This invocation has been mimicked here.

- Running gcov and codecov from the cmake build directory does not work due to path issues regarding the coverage report file names. Instead, we run them from the project root directory.  This works without needing any file path fixes in a codecov.yml configuration.

- In light of the supply chain attack on codecov's bash uploader, we compare checksums on the new uploader

**Other notes:**

- I have disabled `fail-fast` for the mac and linux build matrices due to two issues that are presently ongoing:
 
  - The opensuse/tumbleweed docker image has been broken for about a week.  See their pipeline failure [here](https://openqa.opensuse.org/tests/1926064#step/docker_image/182) and associated bug report [here](https://bugzilla.opensuse.org/show_bug.cgi?id=1190670).

  - Race condition that arises when multiple item tarballs are downloaded simultaneously from openkim.org (although I expect this will be resolved in short order)