### PR TITLE
TST: Create coverity scan workflow

### DIFF
--- a/.github/workflows/coverity-scan.yml
+++ b/.github/workflows/coverity-scan.yml
@@ -1,0 +1,120 @@
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the Common Development
+# and Distribution License Version 1.0 (the "License").
+#
+# You can obtain a copy of the license at
+# http://www.opensource.org/licenses/CDDL-1.0.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each file and
+# include the License file in a prominent location with the name LICENSE.CDDL.
+# If applicable, add the following below this CDDL HEADER, with the fields
+# enclosed by brackets "[]" replaced with your own identifying information:
+#
+# Portions Copyright (c) [yyyy] [name of copyright owner]. All rights reserved.
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright (c) 2021, Regents of the University of Minnesota.
+# All rights reserved.
+#
+# Contributors:
+#    Daniel S. Karls
+
+#
+# Release: This file is part of the kim-api.git repository.
+#
+
+name: Coverity scan
+
+# Run only when pushing to dedicated 'coverity_scan' branch
+on:
+  push:
+    branches:
+      - 'coverity_scan'
+
+jobs:
+
+  coverity-scan:
+
+    name: Coverity scan
+
+    runs-on:
+      ubuntu-latest
+
+    env:
+      COVERITY_DIR: /home/runner/coverity-scan/
+      COVERITY_INTERMEDIATE_DIR: cov-int
+      BUILD_DIR: build
+
+    steps:
+
+      - name: Check out repository
+        uses: actions/checkout@v2
+
+      # TODO: Reuse some of the docker environments for this
+      - name: Configure environment
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            make \
+            cmake \
+            gcc \
+            g++ \
+            gfortran \
+            xxd \
+            curl
+
+      - name: Initialize coverity cache
+        id: coverity-cache
+        uses: actions/cache@v2
+        with:
+          path: ${{ env.COVERITY_DIR }}
+          key: coverity-${{ github.sha }}
+          restore-keys: |
+            coverity
+
+      - name: Download coverity
+        if: steps.coverity-cache.outputs.cache-hit != 'true'
+        env:
+          TOKEN: ${{ secrets.COVERITY_SCAN_TOKEN }}
+          COVERITY_TARBALL: coverity_tool.tgz
+          COVERITY_CHECKSUM_FILE: coverity_tool.md5
+        run: |
+          mkdir -p ${{ env.COVERITY_DIR }}
+          wget https://scan.coverity.com/download/linux64 \
+            --post-data "token=${TOKEN}&project=${{ github.repository_owner }}%2Fkim-api" \
+            -O ${{ env.COVERITY_TARBALL }}
+          wget https://scan.coverity.com/download/linux64 \
+            --post-data "token=${TOKEN}&project=${{ github.repository_owner }}%2Fkim-api&md5=1" \
+            -O ${{ env.COVERITY_CHECKSUM_FILE }}
+          echo "  ${{ env.COVERITY_TARBALL }}" >> ${{ env.COVERITY_CHECKSUM_FILE }}
+          md5sum -c ${{ env.COVERITY_CHECKSUM_FILE }}
+          tar xzf ${{ env.COVERITY_TARBALL }} --strip 1 -C ${{ env.COVERITY_DIR }}
+          rm ${{ env.COVERITY_TARBALL }}
+
+      - name: Run coverity
+        run: |
+          mkdir ${{ env.BUILD_DIR }}
+          cd ${{ env.BUILD_DIR }}
+          cmake ..
+          export PATH=${{ env.COVERITY_DIR }}/bin/:${PATH}
+          cov-build --dir ${{ env.COVERITY_INTERMEDIATE_DIR }} make
+
+      - name: Upload scan results
+        env:
+          EMAIL: relliott@umn.edu
+          TOKEN: ${{ secrets.COVERITY_SCAN_TOKEN }}
+          RESULTS_TARBALL: kim-api.tgz
+        run: |
+          tar czf ${{ env.RESULTS_TARBALL }} -C ${{ env.BUILD_DIR }} ${{ env.COVERITY_INTERMEDIATE_DIR }}
+          curl --form token=${TOKEN} \
+               --form email=${EMAIL} \
+               --form file=@${{ env.RESULTS_TARBALL }} \
+               --form version="${GITHUB_SHA}" \
+               --form description="OpenKIM is an online framework for making molecular simulations reliable, reproducible, and portable. Computer implementations of interatomic models are archived in OpenKIM, verified for coding integrity, and tested by computing their predictions for a variety of material properties. Models conforming to the KIM application programming interface (API) work seamlessly with major simulation codes that have adopted the KIM API standard." \
+               https://scan.coverity.com/builds?project=${{ github.repository_owner }}%2Fkim-api


### PR DESCRIPTION
This workflow should mimic what was previously done in the corresponding travisCI job and, just as before, will run whenever a push is made to a branch named `coverity_scan`.

**NOTE**: This workflow requires that a repository secret named `COVERITY_SCAN_TOKEN` be defined