### PR TITLE
ISSUE #95 - fixup difference between MAKE_C_IDENTIFIER and base64-enc…

### DIFF
--- a/utils/base64-encode.cpp
+++ b/utils/base64-encode.cpp
@@ -69,6 +69,28 @@ inline std::string int_to_string(int value)
   return oss.str();
 }
 
+// A C++ implementation of the CMAKE string-operation MAKE_C_IDENTIFIER
+std::string make_c_identifier(const std::string& input) 
+{
+  std::string output;
+  
+  // If the first character is a digit, prepend an underscore
+  if (!input.empty() && std::isdigit(input[0])) 
+    output += '_';
+
+  // Process each character
+  for(int i = 0; i < input.size(); i++)
+  {
+    const char ch = input[i];
+    if (std::isalnum(ch) || ch == '_') 
+      output += ch;  // Keep letters, numbers, and underscores
+    else 
+      output += '_';  // Replace other characters with underscore
+  }
+
+  return output;
+}
+
 int main(int argc, char ** argv)
 {
   if ((argc < 2) || (argc > 4))
@@ -108,11 +130,7 @@ int main(int argc, char ** argv)
     exit(-1);
   }
 
-  std::string encodeFormatFileName = input;
-  std::replace(
-      encodeFormatFileName.begin(), encodeFormatFileName.end(), '.', '_');
-  std::replace(
-      encodeFormatFileName.begin(), encodeFormatFileName.end(), '-', '_');
+  std::string encodeFormatFileName = make_c_identifier(input);
 
   std::string header
       = "extern unsigned char " + encodeFormatFileName + "[] = \n\"";


### PR DESCRIPTION
…ode.cpp

MAKE_C_IDENTIFIER prefixes an underscore if the string starts with a digit. 
The base64-encode.cpp should do the same.