### PR TITLE
arm64 signed char fix

### DIFF
--- a/cpp/src/libb64/libb64.origin
+++ b/cpp/src/libb64/libb64.origin
@@ -52,5 +52,7 @@ libb64 — MODIFIED ORIGIN DETAILS
 <                 *codechar++ = '\"';
 ```
 
-4. LICENSE
+4. Changed all `char` to `signed char` as `char` is platform dependent.
+
+5. LICENSE
    The original license is included in the file `LICENSE`.

--- a/cpp/src/libb64/libb64/include/b64/cdecode.h
+++ b/cpp/src/libb64/libb64/include/b64/cdecode.h
@@ -16,14 +16,14 @@ typedef enum
 typedef struct
 {
 	base64_decodestep step;
-	char plainchar;
+	signed char plainchar;
 } base64_decodestate;
 
 void base64_init_decodestate(base64_decodestate* state_in);
 
-int base64_decode_value(char value_in);
+int base64_decode_value(signed char value_in);
 
-int base64_decode_block(const char* code_in, const int length_in, char* plaintext_out, base64_decodestate* state_in);
+int base64_decode_block(const signed char* code_in, const int length_in, signed char* plaintext_out, base64_decodestate* state_in);
 
 #endif /* BASE64_CDECODE_H */
 

--- a/cpp/src/libb64/libb64/include/b64/cencode.h
+++ b/cpp/src/libb64/libb64/include/b64/cencode.h
@@ -16,17 +16,17 @@ typedef enum
 typedef struct
 {
 	base64_encodestep step;
-	char result;
+	signed char result;
 	int stepcount;
 } base64_encodestate;
 
 void base64_init_encodestate(base64_encodestate* state_in);
 
-char base64_encode_value(char value_in);
+signed char base64_encode_value(signed char value_in);
 
-int base64_encode_block(const char* plaintext_in, int length_in, char* code_out, base64_encodestate* state_in);
+int base64_encode_block(const signed char* plaintext_in, int length_in, signed char* code_out, base64_encodestate* state_in);
 
-int base64_encode_blockend(char* code_out, base64_encodestate* state_in);
+int base64_encode_blockend(signed char* code_out, base64_encodestate* state_in);
 
 #endif /* BASE64_CENCODE_H */
 

--- a/cpp/src/libb64/libb64/include/b64/decode.h
+++ b/cpp/src/libb64/libb64/include/b64/decode.h
@@ -26,12 +26,12 @@ namespace base64
 		: _buffersize(buffersize_in)
 		{}
 
-		int decode(char value_in)
+		int decode(signed char value_in)
 		{
 			return base64_decode_value(value_in);
 		}
 
-		int decode(const char* code_in, const int length_in, char* plaintext_out)
+		int decode(const signed char* code_in, const int length_in, signed char* plaintext_out)
 		{
 			return base64_decode_block(code_in, length_in, plaintext_out, &_state);
 		}
@@ -50,7 +50,7 @@ namespace base64
 			{
 				istream_in.read((char*)code, N);
 				codelength = istream_in.gcount();
-				plainlength = decode(code, codelength, plaintext);
+				plainlength = decode((const signed char*)code, codelength, (signed char*)plaintext);
 				ostream_in.write((const char*)plaintext, plainlength);
 			}
 			while (istream_in.good() && codelength > 0);

--- a/cpp/src/libb64/libb64/include/b64/encode.h
+++ b/cpp/src/libb64/libb64/include/b64/encode.h
@@ -26,17 +26,17 @@ namespace base64
 		: _buffersize(buffersize_in)
 		{}
 
-		int encode(char value_in)
+		int encode(signed char value_in)
 		{
 			return base64_encode_value(value_in);
 		}
 
-		int encode(const char* code_in, const int length_in, char* plaintext_out)
+		int encode(const signed char* code_in, const int length_in, signed char* plaintext_out)
 		{
 			return base64_encode_block(code_in, length_in, plaintext_out, &_state);
 		}
 
-		int encode_end(char* plaintext_out)
+		int encode_end(signed char* plaintext_out)
 		{
 			return base64_encode_blockend(plaintext_out, &_state);
 		}
@@ -56,12 +56,12 @@ namespace base64
 				istream_in.read(plaintext, N);
 				plainlength = istream_in.gcount();
 				//
-				codelength = encode(plaintext, plainlength, code);
+				codelength = encode((const signed char*)plaintext, plainlength, (signed char*)code);
 				ostream_in.write(code, codelength);
 			}
 			while (istream_in.good() && plainlength > 0);
 
-			codelength = encode_end(code);
+			codelength = encode_end((signed char*)code);
 			ostream_in.write(code, codelength);
 			//
 			base64_init_encodestate(&_state);

--- a/cpp/src/libb64/libb64/src/cdecode.c
+++ b/cpp/src/libb64/libb64/src/cdecode.c
@@ -7,10 +7,10 @@ For details, see http://sourceforge.net/projects/libb64
 
 #include <b64/cdecode.h>
 
-int base64_decode_value(char value_in)
+int base64_decode_value(signed char value_in)
 {
-	static const char decoding[] = {62,-1,-1,-1,63,52,53,54,55,56,57,58,59,60,61,-1,-1,-1,-2,-1,-1,-1,0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,-1,-1,-1,-1,-1,-1,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51};
-	static const char decoding_size = sizeof(decoding);
+	static const signed char decoding[] = {62,-1,-1,-1,63,52,53,54,55,56,57,58,59,60,61,-1,-1,-1,-2,-1,-1,-1,0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,-1,-1,-1,-1,-1,-1,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51};
+	static const signed char decoding_size = sizeof(decoding);
 	value_in -= 43;
 	if (value_in < 0 || value_in >= decoding_size) return -1;
 	return decoding[(int)value_in];
@@ -22,11 +22,11 @@ void base64_init_decodestate(base64_decodestate* state_in)
 	state_in->plainchar = 0;
 }
 
-int base64_decode_block(const char* code_in, const int length_in, char* plaintext_out, base64_decodestate* state_in)
+int base64_decode_block(const signed char* code_in, const int length_in, signed char* plaintext_out, base64_decodestate* state_in)
 {
-	const char* codechar = code_in;
-	char* plainchar = plaintext_out;
-	char fragment;
+	const signed char* codechar = code_in;
+	signed char* plainchar = plaintext_out;
+	signed char fragment;
 	
 	*plainchar = state_in->plainchar;
 	
@@ -42,7 +42,7 @@ int base64_decode_block(const char* code_in, const int length_in, char* plaintex
 					state_in->plainchar = *plainchar;
 					return plainchar - plaintext_out;
 				}
-				fragment = (char)base64_decode_value(*codechar++);
+				fragment = (signed char)base64_decode_value(*codechar++);
 			} while (fragment < 0);
 			*plainchar    = (fragment & 0x03f) << 2;
 	case step_b:
@@ -53,7 +53,7 @@ int base64_decode_block(const char* code_in, const int length_in, char* plaintex
 					state_in->plainchar = *plainchar;
 					return plainchar - plaintext_out;
 				}
-				fragment = (char)base64_decode_value(*codechar++);
+				fragment = (signed char)base64_decode_value(*codechar++);
 			} while (fragment < 0);
 			*plainchar++ |= (fragment & 0x030) >> 4;
 			*plainchar    = (fragment & 0x00f) << 4;
@@ -65,7 +65,7 @@ int base64_decode_block(const char* code_in, const int length_in, char* plaintex
 					state_in->plainchar = *plainchar;
 					return plainchar - plaintext_out;
 				}
-				fragment = (char)base64_decode_value(*codechar++);
+				fragment = (signed char)base64_decode_value(*codechar++);
 			} while (fragment < 0);
 			*plainchar++ |= (fragment & 0x03c) >> 2;
 			*plainchar    = (fragment & 0x003) << 6;
@@ -77,7 +77,7 @@ int base64_decode_block(const char* code_in, const int length_in, char* plaintex
 					state_in->plainchar = *plainchar;
 					return plainchar - plaintext_out;
 				}
-				fragment = (char)base64_decode_value(*codechar++);
+				fragment = (signed char)base64_decode_value(*codechar++);
 			} while (fragment < 0);
 			*plainchar++   |= (fragment & 0x03f);
 		}

--- a/cpp/src/libb64/libb64/src/cencode.c
+++ b/cpp/src/libb64/libb64/src/cencode.c
@@ -16,20 +16,20 @@ void base64_init_encodestate(base64_encodestate* state_in)
 	state_in->stepcount = 0;
 }
 
-char base64_encode_value(char value_in)
+signed char base64_encode_value(signed char value_in)
 {
-	static const char* encoding = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+	static const signed char* encoding = (const signed char*)"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
 	if (value_in > 63) return '=';
 	return encoding[(int)value_in];
 }
 
-int base64_encode_block(const char* plaintext_in, int length_in, char* code_out, base64_encodestate* state_in)
+int base64_encode_block(const signed char* plaintext_in, int length_in, signed char* code_out, base64_encodestate* state_in)
 {
-	const char* plainchar = plaintext_in;
-	const char* const plaintextend = plaintext_in + length_in;
-	char* codechar = code_out;
-	char result;
-	char fragment;
+	const signed char* plainchar = plaintext_in;
+	const signed char* const plaintextend = plaintext_in + length_in;
+	signed char* codechar = code_out;
+	signed char result;
+	signed char fragment;
 	
 	result = state_in->result;
 	
@@ -86,9 +86,9 @@ int base64_encode_block(const char* plaintext_in, int length_in, char* code_out,
 	return codechar - code_out;
 }
 
-int base64_encode_blockend(char* code_out, base64_encodestate* state_in)
+int base64_encode_blockend(signed char* code_out, base64_encodestate* state_in)
 {
-	char* codechar = code_out;
+	signed char* codechar = code_out;
 	
 	switch (state_in->step)
 	{

--- a/utils/base64-encode.cpp
+++ b/utils/base64-encode.cpp
@@ -80,7 +80,7 @@ std::string make_c_identifier(const std::string & input)
   // Process each character
   for (int i = 0; i < input.size(); i++)
   {
-    const char ch = input[i];
+    const signed char ch = input[i];
     if (std::isalnum(ch) || ch == '_')
       output += ch;  // Keep letters, numbers, and underscores
     else


### PR DESCRIPTION
@ilia-nikiforov-umn @nav-mohan
Replaced `char` with `signed char` wherever possible in the base64 module. This should fix the arm64 issues. Please review and test once. I did not have exact tests.